### PR TITLE
Release version 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ import polynomial.`object`.*
 import polynomial.morphism.~>
 import polynomial.product.{◁, ⊗}
 
-type `2y⁵¹²`           = Monomial.Interface[(Byte, Boolean), Boolean, _]
-type `y² + 2y`         = Binomial.Interface[Boolean, Unit, Unit, Boolean, _]
-type `2y²`             = Monomial.Store[Boolean, _]
-type `0`               = Monomial.Interface[Nothing, Nothing, _]
-type `1`               = Monomial.Interface[Unit, Nothing, _]
+type `2y⁵¹²`           = Mono.Interface[(Byte, Boolean), Boolean, _]
+type `y² + 2y`         = Bi.Interface[Boolean, Unit, Unit, Boolean, _]
+type `2y²`             = Mono.Store[Boolean, _]
+type `0`               = Mono.Interface[Nothing, Nothing, _]
+type `1`               = Mono.Interface[Unit, Nothing, _]
 type `y² + 2y → 2y⁵¹²` = (`y² + 2y` ~> `2y⁵¹²`)[_]
 type `4y⁴`             = (`2y²` ⊗ `2y²`)[_]
 type `8y⁴`             = (`2y²` ◁ `2y²`)[_]
@@ -55,7 +55,7 @@ type `8y⁴`             = (`2y²` ◁ `2y²`)[_]
 > - the positions and directions of the polynomial are related by an ADT
 > - the number of terms in the polynomial is equal to the number of members of the ADT
 >
->For example, `Binomial` lens can be pameterized by `Option` such that its
+>For example, `Bi` lens can be pameterized by `Option` such that its
 >terms are exponentiated by `Some[A]` and `None.type`, and behaves as a
 >dual-channeled monomial lens.
 
@@ -71,15 +71,15 @@ be printed, with titles and labels in the following formats:
 
 
 ```scala
-import polynomial.`object`.Monomial.Store
-import polynomial.`object`.Binomial.Interface
+import polynomial.`object`.Mono.Store
+import polynomial.`object`.Bi.Interface
 import polynomial.mermaid.{Format, Mermaid, given}
 import polynomial.morphism.~>
 
 type F[Y] = (Store[Boolean, _] ~> Interface[Some[Byte], None.type, None.type, Some[Char], _])[Y]
 
 val M: Mermaid[F] = summon[Mermaid[F]]
-// M: Mermaid[F] = polynomial.mermaid.Mermaid$$anon$4@3a6123bb
+// M: Mermaid[F] = polynomial.mermaid.Mermaid$$anon$4@2a26a384
 
 println(M.showGraph(graphFmt = Format.Generic))
 // ```mermaid
@@ -109,4 +109,4 @@ classDef title stroke-width:0px, fill:background;
 
 
 
-(Note: GitHub ignores formatting, please use [mermaid.live](https://mermaid.live/))
+(Note: GitHub currently ignores formatting, please use [mermaid.live](https://mermaid.live/))

--- a/README.md
+++ b/README.md
@@ -71,19 +71,26 @@ be printed, with titles and labels in the following formats:
 
 
 ```scala
-import polynomial.`object`.Monomial.{Store, Interface}
+import polynomial.`object`.Monomial.Store
+import polynomial.`object`.Binomial.Interface
 import polynomial.mermaid.{Format, Mermaid, given}
 import polynomial.morphism.~>
 
-type F[Y] = (Store[Boolean, _] ~> Interface[Byte, Char, _])[Y]
+type F[Y] = (Store[Boolean, _] ~> Interface[Some[Byte], None.type, None.type, Some[Char], _])[Y]
 
 val M: Mermaid[F] = summon[Mermaid[F]]
-// M: Mermaid[F] = polynomial.mermaid.Mermaid$$anon$1@5e90ebb6
+// M: Mermaid[F] = polynomial.mermaid.Mermaid$$anon$4@3a6123bb
 
 println(M.showGraph(graphFmt = Format.Generic))
 // ```mermaid
 // graph LR;
-//   A:::hidden---|<span style="font-family:Courier">A</span>|S[<span style="font-family:Courier">S</span>]---|<span style="font-family:Courier">B</span>|B:::hidden;
+//   A1[A1]:::hidden---|<span style="font-family:Courier">A<sub>1</sub></span>
+//     |SS[<span style="font-family:Courier">S</span>]
+//   ---|<span style="font-family:Courier">B<sub>1</sub></span>|A2:::hidden
+//     ~~~
+//   C[A2]:::hidden---|<span style="font-family:Courier">A<sub>2</sub></span>
+//     |TS[<span style="font-family:Courier">S</span>]
+//   ---|<span style="font-family:Courier">B<sub>2</sub></span>|D:::hidden;
 // 
 // classDef empty fill:background;
 // classDef point width:0px, height:0px;

--- a/README.md
+++ b/README.md
@@ -9,15 +9,11 @@ Based on the polynomial functors described in [Niu and Spivak](https://topos.sit
  - mermaid integration (optional)
  
 ```scala
-"com.julianpeeters" %% "polynomial" % "0.4.0" 
-"com.julianpeeters" %% "polynomial-mermaid" % "0.4.0"
+"com.julianpeeters" %% "polynomial" % "0.5.0" 
+"com.julianpeeters" %% "polynomial-mermaid" % "0.5.0"
 ```
 
 ---
-
-### Modules
- - [`polynomial`](#polynomial-1): objects, morphisms, products
- - [`polynomial-mermaid`](#polynomial-mermaid): print mermaid chart definitions
 
 ### `polynomial`
 
@@ -31,16 +27,14 @@ The `polynomial` library provides the following implementation of poly:
 ```scala
 import polynomial.`object`.*
 import polynomial.morphism.~>
-import polynomial.product.{◁, ⊗}
 
-type `2y⁵¹²`           = Mono.Interface[(Byte, Boolean), Boolean, _]
-type `y² + 2y`         = Bi.Interface[Boolean, Unit, Unit, Boolean, _]
-type `2y²`             = Mono.Store[Boolean, _]
-type `0`               = Mono.Interface[Nothing, Nothing, _]
-type `1`               = Mono.Interface[Unit, Nothing, _]
+// Example types:
+type `2y⁵¹²`           = Monomial.Interface[(Byte, Boolean), Boolean, _]
+type `y² + 2y`         = Binomial.BiInterface[Boolean, Unit, Unit, Boolean, _]
+type `2y²`             = Monomial.Store[Boolean, _]
+type `0`               = Monomial.Interface[Nothing, Nothing, _]
+type `1`               = Monomial.Interface[Unit, Nothing, _]
 type `y² + 2y → 2y⁵¹²` = (`y² + 2y` ~> `2y⁵¹²`)[_]
-type `4y⁴`             = (`2y²` ⊗ `2y²`)[_]
-type `8y⁴`             = (`2y²` ◁ `2y²`)[_]
 ```
 
 #### FAQ
@@ -71,26 +65,19 @@ be printed, with titles and labels in the following formats:
 
 
 ```scala
-import polynomial.`object`.Mono.Store
-import polynomial.`object`.Bi.Interface
+import polynomial.`object`.Monomial.{Interface, Store}
 import polynomial.mermaid.{Format, Mermaid, given}
 import polynomial.morphism.~>
 
-type F[Y] = (Store[Boolean, _] ~> Interface[Some[Byte], None.type, None.type, Some[Char], _])[Y]
+type F[Y] = (Store[Boolean, _] ~> Interface[Byte, Char, _])[Y]
 
 val M: Mermaid[F] = summon[Mermaid[F]]
-// M: Mermaid[F] = polynomial.mermaid.Mermaid$$anon$4@2a26a384
+// M: Mermaid[F] = polynomial.mermaid.Mermaid$$anon$1@3fc89d02
 
 println(M.showGraph(graphFmt = Format.Generic))
 // ```mermaid
 // graph LR;
-//   A1[A1]:::hidden---|<span style="font-family:Courier">A<sub>1</sub></span>
-//     |SS[<span style="font-family:Courier">S</span>]
-//   ---|<span style="font-family:Courier">B<sub>1</sub></span>|A2:::hidden
-//     ~~~
-//   C[A2]:::hidden---|<span style="font-family:Courier">A<sub>2</sub></span>
-//     |TS[<span style="font-family:Courier">S</span>]
-//   ---|<span style="font-family:Courier">B<sub>2</sub></span>|D:::hidden;
+//   A:::hidden---|<span style="font-family:Courier">A</span>|S[<span style="font-family:Courier">S</span>]---|<span style="font-family:Courier">B</span>|B:::hidden;
 // 
 // classDef empty fill:background;
 // classDef point width:0px, height:0px;
@@ -106,7 +93,6 @@ classDef empty fill:background;
 classDef point width:0px, height:0px;
 classDef title stroke-width:0px, fill:background;
 ```
-
 
 
 (Note: GitHub currently ignores formatting, please use [mermaid.live](https://mermaid.live/))

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ inThisBuild(List(
     "-Wvalue-discard",
     "-Ykind-projector:underscores"
   ),
-  scalaVersion := "3.3.1",
+  scalaVersion := "3.4.0",
   versionScheme := Some("semver-spec"),
 ))
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+val CatsV = "2.10.0"
 val TypenameV = "0.2.0"
 val TypesizeV = "0.1.0"
 
@@ -31,6 +32,9 @@ lazy val poly = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("modules/poly"))
   .settings(
     name := "polynomial",
+    libraryDependencies ++= Seq(
+      "org.typelevel" %%% "cats-core" % CatsV,
+    )
   )
 
 lazy val mermaid = crossProject(JSPlatform, JVMPlatform, NativePlatform)

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -33,11 +33,11 @@ import polynomial.`object`.*
 import polynomial.morphism.~>
 import polynomial.product.{◁, ⊗}
 
-type `2y⁵¹²`           = Monomial.Interface[(Byte, Boolean), Boolean, _]
-type `y² + 2y`         = Binomial.Interface[Boolean, Unit, Unit, Boolean, _]
-type `2y²`             = Monomial.Store[Boolean, _]
-type `0`               = Monomial.Interface[Nothing, Nothing, _]
-type `1`               = Monomial.Interface[Unit, Nothing, _]
+type `2y⁵¹²`           = Mono.Interface[(Byte, Boolean), Boolean, _]
+type `y² + 2y`         = Bi.Interface[Boolean, Unit, Unit, Boolean, _]
+type `2y²`             = Mono.Store[Boolean, _]
+type `0`               = Mono.Interface[Nothing, Nothing, _]
+type `1`               = Mono.Interface[Unit, Nothing, _]
 type `y² + 2y → 2y⁵¹²` = (`y² + 2y` ~> `2y⁵¹²`)[_]
 type `4y⁴`             = (`2y²` ⊗ `2y²`)[_]
 type `8y⁴`             = (`2y²` ◁ `2y²`)[_]
@@ -55,7 +55,7 @@ type `8y⁴`             = (`2y²` ◁ `2y²`)[_]
 > - the positions and directions of the polynomial are related by an ADT
 > - the number of terms in the polynomial is equal to the number of members of the ADT
 >
->For example, `Binomial` lens can be pameterized by `Option` such that its
+>For example, `Bi` lens can be pameterized by `Option` such that its
 >terms are exponentiated by `Some[A]` and `None.type`, and behaves as a
 >dual-channeled monomial lens.
 
@@ -71,8 +71,8 @@ be printed, with titles and labels in the following formats:
 
 
 ```scala mdoc:reset
-import polynomial.`object`.Monomial.Store
-import polynomial.`object`.Binomial.Interface
+import polynomial.`object`.Mono.Store
+import polynomial.`object`.Bi.Interface
 import polynomial.mermaid.{Format, Mermaid, given}
 import polynomial.morphism.~>
 
@@ -94,18 +94,18 @@ classDef title stroke-width:0px, fill:background;
 
 
 ```scala mdoc:reset:passthrough
-import polynomial.`object`.Monomial
+import polynomial.`object`.Mono
 // import polynomial.mermaid.{Format, Mermaid, given}
 import polynomial.morphism.~>
 import polynomial.product.⊗
 
-type Plant[Y]      = Monomial.Interface[(Byte, Char), Char, Y]
-type Controller[Y] = Monomial.Interface[Char, Char, Y]
-type System[Y]     = Monomial.Interface[Byte, Char, Y]
+type Plant[Y]      = Mono.Interface[(Byte, Char), Char, Y]
+type Controller[Y] = Mono.Interface[Char, Char, Y]
+type System[Y]     = Mono.Interface[Byte, Char, Y]
 
 type F[Y] = ((Plant ⊗ Controller) ~> System)[Y]
 
 // println(summon[Mermaid[F]].showTitledGraph(titleFmt = Format.Generic, graphFmt = Format.Generic))
 ```
 
-(Note: GitHub ignores formatting, please use [mermaid.live](https://mermaid.live/))
+(Note: GitHub currently ignores formatting, please use [mermaid.live](https://mermaid.live/))

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -71,11 +71,12 @@ be printed, with titles and labels in the following formats:
 
 
 ```scala mdoc:reset
-import polynomial.`object`.Monomial.{Store, Interface}
+import polynomial.`object`.Monomial.Store
+import polynomial.`object`.Binomial.Interface
 import polynomial.mermaid.{Format, Mermaid, given}
 import polynomial.morphism.~>
 
-type F[Y] = (Store[Boolean, _] ~> Interface[Byte, Char, _])[Y]
+type F[Y] = (Store[Boolean, _] ~> Interface[Some[Byte], None.type, None.type, Some[Char], _])[Y]
 
 val M: Mermaid[F] = summon[Mermaid[F]]
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -27,16 +27,14 @@ The `polynomial` library provides the following implementation of poly:
 ```scala mdoc
 import polynomial.`object`.*
 import polynomial.morphism.~>
-import polynomial.product.{◁, ⊗}
 
-type `2y⁵¹²`           = Mono.Interface[(Byte, Boolean), Boolean, _]
-type `y² + 2y`         = Bi.Interface[Boolean, Unit, Unit, Boolean, _]
-type `2y²`             = Mono.Store[Boolean, _]
-type `0`               = Mono.Interface[Nothing, Nothing, _]
-type `1`               = Mono.Interface[Unit, Nothing, _]
+// Example types:
+type `2y⁵¹²`           = Monomial.Interface[(Byte, Boolean), Boolean, _]
+type `y² + 2y`         = Binomial.BiInterface[Boolean, Unit, Unit, Boolean, _]
+type `2y²`             = Monomial.Store[Boolean, _]
+type `0`               = Monomial.Interface[Nothing, Nothing, _]
+type `1`               = Monomial.Interface[Unit, Nothing, _]
 type `y² + 2y → 2y⁵¹²` = (`y² + 2y` ~> `2y⁵¹²`)[_]
-type `4y⁴`             = (`2y²` ⊗ `2y²`)[_]
-type `8y⁴`             = (`2y²` ◁ `2y²`)[_]
 ```
 
 #### FAQ
@@ -67,12 +65,11 @@ be printed, with titles and labels in the following formats:
 
 
 ```scala mdoc:reset
-import polynomial.`object`.Mono.Store
-import polynomial.`object`.Bi.Interface
+import polynomial.`object`.Monomial.{Interface, Store}
 import polynomial.mermaid.{Format, Mermaid, given}
 import polynomial.morphism.~>
 
-type F[Y] = (Store[Boolean, _] ~> Interface[Some[Byte], None.type, None.type, Some[Char], _])[Y]
+type F[Y] = (Store[Boolean, _] ~> Interface[Byte, Char, _])[Y]
 
 val M: Mermaid[F] = summon[Mermaid[F]]
 
@@ -88,20 +85,5 @@ classDef point width:0px, height:0px;
 classDef title stroke-width:0px, fill:background;
 ```
 
-
-```scala mdoc:reset:passthrough
-import polynomial.`object`.Mono
-// import polynomial.mermaid.{Format, Mermaid, given}
-import polynomial.morphism.~>
-import polynomial.product.⊗
-
-type Plant[Y]      = Mono.Interface[(Byte, Char), Char, Y]
-type Controller[Y] = Mono.Interface[Char, Char, Y]
-type System[Y]     = Mono.Interface[Byte, Char, Y]
-
-type F[Y] = ((Plant ⊗ Controller) ~> System)[Y]
-
-// println(summon[Mermaid[F]].showTitledGraph(titleFmt = Format.Generic, graphFmt = Format.Generic))
-```
 
 (Note: GitHub currently ignores formatting, please use [mermaid.live](https://mermaid.live/))

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -15,10 +15,6 @@ Based on the polynomial functors described in [Niu and Spivak](https://topos.sit
 
 ---
 
-### Modules
- - [`polynomial`](#polynomial-1): objects, morphisms, products
- - [`polynomial-mermaid`](#polynomial-mermaid): print mermaid chart definitions
-
 ### `polynomial`
 
 The `polynomial` library provides the following implementation of poly:

--- a/modules/mermaid/shared/src/main/scala/polynomial/mermaid/Mermaid.scala
+++ b/modules/mermaid/shared/src/main/scala/polynomial/mermaid/Mermaid.scala
@@ -6,10 +6,10 @@ import polynomial.mermaid.render.q.MermaidQ
 import polynomial.mermaid.render.Format.{Cardinal, Generic, Specific}
 import polynomial.mermaid.render.{Render, addTitle}
 import polynomial.morphism.PolyMap
-import polynomial.`object`.{Binomial, Monomial}
+import polynomial.`object`.{Bi, Mono}
 import polynomial.product.⊗
-import polynomial.`object`.Monomial.Interface
-import polynomial.`object`.Monomial.Store
+import polynomial.`object`.Mono.Interface
+import polynomial.`object`.Mono.Store
 import polynomial.product.Tensor
 
 trait Mermaid[F[_]]:
@@ -26,28 +26,28 @@ object Mermaid:
 
   type CustomLabels[X] = X match
     case PolyMap[p, q, y] => CustomLabels[(p[y], q[y])]
-    case (Monomial.Interface[a1, b1, y1], Monomial.Interface[a2, b2, y2]) => (String, String)
-    case (Monomial.Store[s, y1], Binomial.Interface[a1, b1, a2, b2, y2]) => (String, String)
-    case (Monomial.Store[s, y1], Monomial.Interface[a, b, y2]) => (String, String)
-    case (Monomial.Store[s1, y1], Monomial.Store[s2, y2]) => (String, String)
-    case (Tensor[o, p, y1], Monomial.Interface[q, r, y2]) => (CustomLabels[(o[y1], p[y1])], String)
+    case (Mono.Interface[a1, b1, y1], Mono.Interface[a2, b2, y2]) => (String, String)
+    case (Mono.Store[s, y1], Bi.Interface[a1, b1, a2, b2, y2]) => (String, String)
+    case (Mono.Store[s, y1], Mono.Interface[a, b, y2]) => (String, String)
+    case (Mono.Store[s1, y1], Mono.Store[s2, y2]) => (String, String)
+    case (Tensor[o, p, y1], Mono.Interface[q, r, y2]) => (CustomLabels[(o[y1], p[y1])], String)
     case (Tensor[o, p, y1], Tensor[q, r, y2]) => (CustomLabels[(o[y1], p[y1])], CustomLabels[(q[y2], r[y2])])
 
   type ParamLabels[X] = X match
-    case Monomial.Interface[a, b, y] => (String, String)
-    case Binomial.Interface[a1, b1, a2, b2, y] => ((String, String), (String, String))
-    case Monomial.Store[s, y] => String
+    case Mono.Interface[a, b, y] => (String, String)
+    case Bi.Interface[a1, b1, a2, b2, y] => ((String, String), (String, String))
+    case Mono.Store[s, y] => String
     
   type PolynomialLabels[X] = X match
-    case Binomial.Interface[a1, b1, a2, b2, y] => String
-    case Monomial.Interface[a, b, y] => String
-    case Monomial.Store[s, y] => String
+    case Bi.Interface[a1, b1, a2, b2, y] => String
+    case Mono.Interface[a, b, y] => String
+    case Mono.Store[s, y] => String
 
   given mooreStoreToMono[S, A, B](using
-    P: MermaidP[Monomial.Store[S, _]],
-    Q: MermaidQ[Monomial.Interface[A, B, _]],
-  ): Mermaid[PolyMap[Monomial.Store[S, _], Monomial.Interface[A, B, _], _]] =
-    new Mermaid[PolyMap[Monomial.Store[S, _], Monomial.Interface[A, B, _], _]]:
+    P: MermaidP[Mono.Store[S, _]],
+    Q: MermaidQ[Mono.Interface[A, B, _]],
+  ): Mermaid[PolyMap[Mono.Store[S, _], Mono.Interface[A, B, _], _]] =
+    new Mermaid[PolyMap[Mono.Store[S, _], Mono.Interface[A, B, _], _]]:
       private val labelS: String = "S"
       private val labelA: String = "A"
       private val labelB: String = "B"
@@ -129,10 +129,10 @@ object Mermaid:
               .addTitle(labels._1, 3, labels._2, 3)
         
   given mealyStoreToMono[S, A, B](using
-    P: MermaidP[Monomial.Store[S, _]],
-    Q: MermaidQ[Monomial.Interface[A, A => B, _]],
-  ): Mermaid[PolyMap[Monomial.Store[S, _], Monomial.Interface[A, A => B, _], _]] =
-    new Mermaid[PolyMap[Monomial.Store[S, _], Monomial.Interface[A, A => B, _], _]]:
+    P: MermaidP[Mono.Store[S, _]],
+    Q: MermaidQ[Mono.Interface[A, A => B, _]],
+  ): Mermaid[PolyMap[Mono.Store[S, _], Mono.Interface[A, A => B, _], _]] =
+    new Mermaid[PolyMap[Mono.Store[S, _], Mono.Interface[A, A => B, _], _]]:
       private val labelS = "S"
       private val labelA = "A"
       private val labelB = "B"
@@ -214,10 +214,10 @@ object Mermaid:
               .addTitle(labels._1, 3, labels._2, 3)
 
   given monoToMono[A1, B1, A2, B2](using
-    P: MermaidP[Monomial.Interface[A1, B1, _]],
-    Q: MermaidQ[Monomial.Interface[A2, B2, _]],
-  ): Mermaid[PolyMap[Monomial.Interface[A1, B1, _], Monomial.Interface[A2, B2, _], _]] =
-    new Mermaid[PolyMap[Monomial.Interface[A1, B1, _], Monomial.Interface[A2, B2, _], _]]:
+    P: MermaidP[Mono.Interface[A1, B1, _]],
+    Q: MermaidQ[Mono.Interface[A2, B2, _]],
+  ): Mermaid[PolyMap[Mono.Interface[A1, B1, _], Mono.Interface[A2, B2, _], _]] =
+    new Mermaid[PolyMap[Mono.Interface[A1, B1, _], Mono.Interface[A2, B2, _], _]]:
       private val labelA1 = "A<sub>1</sub>"
       private val labelB1 = "B<sub>1</sub>"
       private val labelA2 = "A<sub>2</sub>"
@@ -304,10 +304,10 @@ object Mermaid:
               .addTitle(labels._1, 4, labels._2, 4)
         
   given mooreStoreToBi[S, A1, B1, A2, B2](using
-    P: MermaidP[Monomial.Store[S, _]],
-    Q: MermaidQ[Binomial.Interface[A1, B1, A2, B2, _]],
-  ): Mermaid[PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], _]] =
-    new Mermaid[PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], _]]:
+    P: MermaidP[Mono.Store[S, _]],
+    Q: MermaidQ[Bi.Interface[A1, B1, A2, B2, _]],
+  ): Mermaid[PolyMap[Mono.Store[S, _], Bi.Interface[A1, B1, A2, B2, _], _]] =
+    new Mermaid[PolyMap[Mono.Store[S, _], Bi.Interface[A1, B1, A2, B2, _], _]]:
       private val labelS = "S"
       private val labelA1 = "A<sub>1</sub>"
       private val labelB1 = "B<sub>1</sub>"
@@ -395,12 +395,12 @@ object Mermaid:
               .addTitle(labels._1, 3, labels._2, 3)
 
   given mooreTensoredStoreToTensoredMonomial[S1, S2, A1, B1, A2, B2](using
-    P1: MermaidP[Monomial.Store[S1, _]],
-    P2: MermaidP[Monomial.Store[S2, _]],
-    Q1: MermaidQ[Monomial.Interface[A1, B1, _]],
-    Q2: MermaidQ[Monomial.Interface[A2, B2, _]],
-  ): Mermaid[PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], _]] =
-    new Mermaid[PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], _]]:
+    P1: MermaidP[Mono.Store[S1, _]],
+    P2: MermaidP[Mono.Store[S2, _]],
+    Q1: MermaidQ[Mono.Interface[A1, B1, _]],
+    Q2: MermaidQ[Mono.Interface[A2, B2, _]],
+  ): Mermaid[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _]] =
+    new Mermaid[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _]]:
       private val labelS1 = "S<sub>1</sub>"
       private val labelS2 = "S<sub>2</sub>"
       private val labelA1 = "A<sub>1</sub>"
@@ -446,12 +446,12 @@ object Mermaid:
         ???
 
   given mooreTensoredMonomialToTensoredMonomial[A1, B1, A2, B2, C1, D1, C2, D2](using
-    P1: MermaidP[Monomial.Interface[A1, B1, _]],
-    P2: MermaidP[Monomial.Interface[A2, B2, _]],
-    Q1: MermaidQ[Monomial.Interface[C1, D1, _]],
-    Q2: MermaidQ[Monomial.Interface[C2, D2, _]],
-  ): Mermaid[PolyMap[Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], Monomial.Interface[C1, D1, _] ⊗ Monomial.Interface[C2, D2, _], _]] =
-    new Mermaid[PolyMap[Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], Monomial.Interface[C1, D1, _] ⊗ Monomial.Interface[C2, D2, _], _]]:
+    P1: MermaidP[Mono.Interface[A1, B1, _]],
+    P2: MermaidP[Mono.Interface[A2, B2, _]],
+    Q1: MermaidQ[Mono.Interface[C1, D1, _]],
+    Q2: MermaidQ[Mono.Interface[C2, D2, _]],
+  ): Mermaid[PolyMap[Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], Mono.Interface[C1, D1, _] ⊗ Mono.Interface[C2, D2, _], _]] =
+    new Mermaid[PolyMap[Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], Mono.Interface[C1, D1, _] ⊗ Mono.Interface[C2, D2, _], _]]:
       private val labelA1 = "A<sub>1</sub>"
       private val labelA2 = "A<sub>2</sub>"
       private val labelB1 = "B<sub>1</sub>"
@@ -517,11 +517,11 @@ object Mermaid:
 
 
   given mooreTensoredMonomialToMonomial[A, B, C](using
-    P1: MermaidP[Monomial.Interface[(A, B), C, _]],
-    P2: MermaidP[Monomial.Interface[C, B, _]],
-    Q: MermaidQ[Monomial.Interface[A, C, _]],
-  ): Mermaid[PolyMap[(Monomial.Interface[(A, B), C, _] ⊗ Monomial.Interface[C, B, _]), Monomial.Interface[A, C, _], _]] =
-    new Mermaid[PolyMap[(Monomial.Interface[(A, B), C, _] ⊗ Monomial.Interface[C, B, _]), Monomial.Interface[A, C, _], _]]:
+    P1: MermaidP[Mono.Interface[(A, B), C, _]],
+    P2: MermaidP[Mono.Interface[C, B, _]],
+    Q: MermaidQ[Mono.Interface[A, C, _]],
+  ): Mermaid[PolyMap[(Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, C, _], _]] =
+    new Mermaid[PolyMap[(Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, C, _], _]]:
       private val labelA = "A"
       private val labelB = "B"
       private val labelC = "C"

--- a/modules/mermaid/shared/src/main/scala/polynomial/mermaid/Mermaid.scala
+++ b/modules/mermaid/shared/src/main/scala/polynomial/mermaid/Mermaid.scala
@@ -6,11 +6,9 @@ import polynomial.mermaid.render.q.MermaidQ
 import polynomial.mermaid.render.Format.{Cardinal, Generic, Specific}
 import polynomial.mermaid.render.{Render, addTitle}
 import polynomial.morphism.PolyMap
-import polynomial.`object`.{Bi, Mono}
-import polynomial.product.⊗
-import polynomial.`object`.Mono.Interface
-import polynomial.`object`.Mono.Store
-import polynomial.product.Tensor
+import polynomial.`object`.Binomial.BiInterface
+import polynomial.`object`.Monomial.{Interface, Store}
+import polynomial.product.{Tensor, ⊗}
 
 trait Mermaid[F[_]]:
   def showGraph(graphFmt: Format): String
@@ -26,28 +24,28 @@ object Mermaid:
 
   type CustomLabels[X] = X match
     case PolyMap[p, q, y] => CustomLabels[(p[y], q[y])]
-    case (Mono.Interface[a1, b1, y1], Mono.Interface[a2, b2, y2]) => (String, String)
-    case (Mono.Store[s, y1], Bi.Interface[a1, b1, a2, b2, y2]) => (String, String)
-    case (Mono.Store[s, y1], Mono.Interface[a, b, y2]) => (String, String)
-    case (Mono.Store[s1, y1], Mono.Store[s2, y2]) => (String, String)
-    case (Tensor[o, p, y1], Mono.Interface[q, r, y2]) => (CustomLabels[(o[y1], p[y1])], String)
+    case (Interface[a1, b1, y1], Interface[a2, b2, y2]) => (String, String)
+    case (Store[s, y1], BiInterface[a1, b1, a2, b2, y2]) => (String, String)
+    case (Store[s, y1], Interface[a, b, y2]) => (String, String)
+    case (Store[s1, y1], Store[s2, y2]) => (String, String)
+    case (Tensor[o, p, y1], Interface[q, r, y2]) => (CustomLabels[(o[y1], p[y1])], String)
     case (Tensor[o, p, y1], Tensor[q, r, y2]) => (CustomLabels[(o[y1], p[y1])], CustomLabels[(q[y2], r[y2])])
 
   type ParamLabels[X] = X match
-    case Mono.Interface[a, b, y] => (String, String)
-    case Bi.Interface[a1, b1, a2, b2, y] => ((String, String), (String, String))
-    case Mono.Store[s, y] => String
+    case Interface[a, b, y] => (String, String)
+    case BiInterface[a1, b1, a2, b2, y] => ((String, String), (String, String))
+    case Store[s, y] => String
     
   type PolynomialLabels[X] = X match
-    case Bi.Interface[a1, b1, a2, b2, y] => String
-    case Mono.Interface[a, b, y] => String
-    case Mono.Store[s, y] => String
+    case BiInterface[a1, b1, a2, b2, y] => String
+    case Interface[a, b, y] => String
+    case Store[s, y] => String
 
   given mooreStoreToMono[S, A, B](using
-    P: MermaidP[Mono.Store[S, _]],
-    Q: MermaidQ[Mono.Interface[A, B, _]],
-  ): Mermaid[PolyMap[Mono.Store[S, _], Mono.Interface[A, B, _], _]] =
-    new Mermaid[PolyMap[Mono.Store[S, _], Mono.Interface[A, B, _], _]]:
+    P: MermaidP[Store[S, _]],
+    Q: MermaidQ[Interface[A, B, _]],
+  ): Mermaid[PolyMap[Store[S, _], Interface[A, B, _], _]] =
+    new Mermaid[PolyMap[Store[S, _], Interface[A, B, _], _]]:
       private val labelS: String = "S"
       private val labelA: String = "A"
       private val labelB: String = "B"
@@ -129,10 +127,10 @@ object Mermaid:
               .addTitle(labels._1, 3, labels._2, 3)
         
   given mealyStoreToMono[S, A, B](using
-    P: MermaidP[Mono.Store[S, _]],
-    Q: MermaidQ[Mono.Interface[A, A => B, _]],
-  ): Mermaid[PolyMap[Mono.Store[S, _], Mono.Interface[A, A => B, _], _]] =
-    new Mermaid[PolyMap[Mono.Store[S, _], Mono.Interface[A, A => B, _], _]]:
+    P: MermaidP[Store[S, _]],
+    Q: MermaidQ[Interface[A, A => B, _]],
+  ): Mermaid[PolyMap[Store[S, _], Interface[A, A => B, _], _]] =
+    new Mermaid[PolyMap[Store[S, _], Interface[A, A => B, _], _]]:
       private val labelS = "S"
       private val labelA = "A"
       private val labelB = "B"
@@ -214,10 +212,10 @@ object Mermaid:
               .addTitle(labels._1, 3, labels._2, 3)
 
   given monoToMono[A1, B1, A2, B2](using
-    P: MermaidP[Mono.Interface[A1, B1, _]],
-    Q: MermaidQ[Mono.Interface[A2, B2, _]],
-  ): Mermaid[PolyMap[Mono.Interface[A1, B1, _], Mono.Interface[A2, B2, _], _]] =
-    new Mermaid[PolyMap[Mono.Interface[A1, B1, _], Mono.Interface[A2, B2, _], _]]:
+    P: MermaidP[Interface[A1, B1, _]],
+    Q: MermaidQ[Interface[A2, B2, _]],
+  ): Mermaid[PolyMap[Interface[A1, B1, _], Interface[A2, B2, _], _]] =
+    new Mermaid[PolyMap[Interface[A1, B1, _], Interface[A2, B2, _], _]]:
       private val labelA1 = "A<sub>1</sub>"
       private val labelB1 = "B<sub>1</sub>"
       private val labelA2 = "A<sub>2</sub>"
@@ -304,10 +302,10 @@ object Mermaid:
               .addTitle(labels._1, 4, labels._2, 4)
         
   given mooreStoreToBi[S, A1, B1, A2, B2](using
-    P: MermaidP[Mono.Store[S, _]],
-    Q: MermaidQ[Bi.Interface[A1, B1, A2, B2, _]],
-  ): Mermaid[PolyMap[Mono.Store[S, _], Bi.Interface[A1, B1, A2, B2, _], _]] =
-    new Mermaid[PolyMap[Mono.Store[S, _], Bi.Interface[A1, B1, A2, B2, _], _]]:
+    P: MermaidP[Store[S, _]],
+    Q: MermaidQ[BiInterface[A1, B1, A2, B2, _]],
+  ): Mermaid[PolyMap[Store[S, _], BiInterface[A1, B1, A2, B2, _], _]] =
+    new Mermaid[PolyMap[Store[S, _], BiInterface[A1, B1, A2, B2, _], _]]:
       private val labelS = "S"
       private val labelA1 = "A<sub>1</sub>"
       private val labelB1 = "B<sub>1</sub>"
@@ -395,12 +393,12 @@ object Mermaid:
               .addTitle(labels._1, 3, labels._2, 3)
 
   given mooreTensoredStoreToTensoredMonomial[S1, S2, A1, B1, A2, B2](using
-    P1: MermaidP[Mono.Store[S1, _]],
-    P2: MermaidP[Mono.Store[S2, _]],
-    Q1: MermaidQ[Mono.Interface[A1, B1, _]],
-    Q2: MermaidQ[Mono.Interface[A2, B2, _]],
-  ): Mermaid[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _]] =
-    new Mermaid[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _]]:
+    P1: MermaidP[Store[S1, _]],
+    P2: MermaidP[Store[S2, _]],
+    Q1: MermaidQ[Interface[A1, B1, _]],
+    Q2: MermaidQ[Interface[A2, B2, _]],
+  ): Mermaid[PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], _]] =
+    new Mermaid[PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], _]]:
       private val labelS1 = "S<sub>1</sub>"
       private val labelS2 = "S<sub>2</sub>"
       private val labelA1 = "A<sub>1</sub>"
@@ -446,12 +444,12 @@ object Mermaid:
         ???
 
   given mooreTensoredMonomialToTensoredMonomial[A1, B1, A2, B2, C1, D1, C2, D2](using
-    P1: MermaidP[Mono.Interface[A1, B1, _]],
-    P2: MermaidP[Mono.Interface[A2, B2, _]],
-    Q1: MermaidQ[Mono.Interface[C1, D1, _]],
-    Q2: MermaidQ[Mono.Interface[C2, D2, _]],
-  ): Mermaid[PolyMap[Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], Mono.Interface[C1, D1, _] ⊗ Mono.Interface[C2, D2, _], _]] =
-    new Mermaid[PolyMap[Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], Mono.Interface[C1, D1, _] ⊗ Mono.Interface[C2, D2, _], _]]:
+    P1: MermaidP[Interface[A1, B1, _]],
+    P2: MermaidP[Interface[A2, B2, _]],
+    Q1: MermaidQ[Interface[C1, D1, _]],
+    Q2: MermaidQ[Interface[C2, D2, _]],
+  ): Mermaid[PolyMap[Interface[A1, B1, _] ⊗ Interface[A2, B2, _], Interface[C1, D1, _] ⊗ Interface[C2, D2, _], _]] =
+    new Mermaid[PolyMap[Interface[A1, B1, _] ⊗ Interface[A2, B2, _], Interface[C1, D1, _] ⊗ Interface[C2, D2, _], _]]:
       private val labelA1 = "A<sub>1</sub>"
       private val labelA2 = "A<sub>2</sub>"
       private val labelB1 = "B<sub>1</sub>"
@@ -517,11 +515,11 @@ object Mermaid:
 
 
   given mooreTensoredMonomialToMonomial[A, B, C](using
-    P1: MermaidP[Mono.Interface[(A, B), C, _]],
-    P2: MermaidP[Mono.Interface[C, B, _]],
-    Q: MermaidQ[Mono.Interface[A, C, _]],
-  ): Mermaid[PolyMap[(Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, C, _], _]] =
-    new Mermaid[PolyMap[(Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, C, _], _]]:
+    P1: MermaidP[Interface[(A, B), C, _]],
+    P2: MermaidP[Interface[C, B, _]],
+    Q: MermaidQ[Interface[A, C, _]],
+  ): Mermaid[PolyMap[(Interface[(A, B), C, _] ⊗ Interface[C, B, _]), Interface[A, C, _], _]] =
+    new Mermaid[PolyMap[(Interface[(A, B), C, _] ⊗ Interface[C, B, _]), Interface[A, C, _], _]]:
       private val labelA = "A"
       private val labelB = "B"
       private val labelC = "C"

--- a/modules/mermaid/shared/src/main/scala/polynomial/mermaid/render/p/MermaidP.scala
+++ b/modules/mermaid/shared/src/main/scala/polynomial/mermaid/render/p/MermaidP.scala
@@ -2,7 +2,7 @@ package polynomial.mermaid.render.p
 
 import polynomial.mermaid.Mermaid.{ParamLabels, PolynomialLabels}
 import polynomial.mermaid.render.{Font, Render}
-import polynomial.`object`.Mono
+import polynomial.`object`.Monomial.{Interface, Store}
 import typename.NameOf
 import typesize.SizeOf
 
@@ -25,8 +25,8 @@ trait MermaidP[P[_]]:
 
 object MermaidP:
 
-  given [S](using N: NameOf[S], S: SizeOf[S]): MermaidP[Mono.Store[S, _]] =
-    new MermaidP[Mono.Store[S, _]]:
+  given [S](using N: NameOf[S], S: SizeOf[S]): MermaidP[Store[S, _]] =
+    new MermaidP[Store[S, _]]:
       def graphP[Y](nodeLabels: String, polynomialLabelP: String, paramLabelsP: String): String =
         s"$nodeLabels[$paramLabelsP]"
       def graphPCardinal[Y](nodeLabels: String, polynomialLabelP: String): String =
@@ -48,8 +48,8 @@ object MermaidP:
       def variableLabel: String =
         Render.y
 
-  given [A, B](using NA: NameOf[A], NB: NameOf[B], SA: SizeOf[A], SB: SizeOf[B]): MermaidP[Mono.Interface[A, B, _]] =
-    new MermaidP[Mono.Interface[A, B, _]]:
+  given [A, B](using NA: NameOf[A], NB: NameOf[B], SA: SizeOf[A], SB: SizeOf[B]): MermaidP[Interface[A, B, _]] =
+    new MermaidP[Interface[A, B, _]]:
       def graphP[Y](nodeLabels: String, polynomialLabelP: String, paramLabelsP: (String, String)): String =
       s"""|A_${nodeLabels}[ ]:::point
           |subgraph s[ ]

--- a/modules/mermaid/shared/src/main/scala/polynomial/mermaid/render/p/MermaidP.scala
+++ b/modules/mermaid/shared/src/main/scala/polynomial/mermaid/render/p/MermaidP.scala
@@ -2,7 +2,7 @@ package polynomial.mermaid.render.p
 
 import polynomial.mermaid.Mermaid.{ParamLabels, PolynomialLabels}
 import polynomial.mermaid.render.{Font, Render}
-import polynomial.`object`.Monomial
+import polynomial.`object`.Mono
 import typename.NameOf
 import typesize.SizeOf
 
@@ -25,8 +25,8 @@ trait MermaidP[P[_]]:
 
 object MermaidP:
 
-  given [S](using N: NameOf[S], S: SizeOf[S]): MermaidP[Monomial.Store[S, _]] =
-    new MermaidP[Monomial.Store[S, _]]:
+  given [S](using N: NameOf[S], S: SizeOf[S]): MermaidP[Mono.Store[S, _]] =
+    new MermaidP[Mono.Store[S, _]]:
       def graphP[Y](nodeLabels: String, polynomialLabelP: String, paramLabelsP: String): String =
         s"$nodeLabels[$paramLabelsP]"
       def graphPCardinal[Y](nodeLabels: String, polynomialLabelP: String): String =
@@ -48,8 +48,8 @@ object MermaidP:
       def variableLabel: String =
         Render.y
 
-  given [A, B](using NA: NameOf[A], NB: NameOf[B], SA: SizeOf[A], SB: SizeOf[B]): MermaidP[Monomial.Interface[A, B, _]] =
-    new MermaidP[Monomial.Interface[A, B, _]]:
+  given [A, B](using NA: NameOf[A], NB: NameOf[B], SA: SizeOf[A], SB: SizeOf[B]): MermaidP[Mono.Interface[A, B, _]] =
+    new MermaidP[Mono.Interface[A, B, _]]:
       def graphP[Y](nodeLabels: String, polynomialLabelP: String, paramLabelsP: (String, String)): String =
       s"""|A_${nodeLabels}[ ]:::point
           |subgraph s[ ]

--- a/modules/mermaid/shared/src/main/scala/polynomial/mermaid/render/q/MermaidQ.scala
+++ b/modules/mermaid/shared/src/main/scala/polynomial/mermaid/render/q/MermaidQ.scala
@@ -2,7 +2,7 @@ package polynomial.mermaid.render.q
 
 import polynomial.mermaid.Mermaid.ParamLabels
 import polynomial.mermaid.render.{Font, Render}
-import polynomial.`object`.{Binomial, Monomial}
+import polynomial.`object`.{Bi, Mono}
 import typename.NameOf
 import typesize.SizeOf
 
@@ -32,8 +32,8 @@ object MermaidQ:
       NB: NameOf[B],
       SA: SizeOf[A],
       SB: SizeOf[B]
-    ): MermaidQ[Monomial.Interface[A, B, _]] =
-    new MermaidQ[Monomial.Interface[A, B, _]]:
+    ): MermaidQ[Mono.Interface[A, B, _]] =
+    new MermaidQ[Mono.Interface[A, B, _]]:
       def graphQ[Y](p: String, nodeLabels: (String, String), paramLabelsQ: (String, String)) =
         s"${nodeLabels._1}:::hidden---|${paramLabelsQ._1}|${p}---|${paramLabelsQ._2}|${nodeLabels._2}:::hidden;"
       def graphQCardinal(nodeLabels: (String, String)): String => String =
@@ -63,8 +63,8 @@ object MermaidQ:
       NB: NameOf[B],
       SA: SizeOf[A],
       SB: SizeOf[B]
-    ): MermaidQ[Monomial.Interface[A, A => B, _]] =
-    new MermaidQ[Monomial.Interface[A, A => B, _]]:
+    ): MermaidQ[Mono.Interface[A, A => B, _]] =
+    new MermaidQ[Mono.Interface[A, A => B, _]]:
       def graphQ[Y](p: String, nodeLabels: (String, String), paramLabelsQ: (String, String)) =
         s"${nodeLabels._1}:::hidden---|${paramLabelsQ._1}|${p}---|${paramLabelsQ._2}|${nodeLabels._2}:::hidden;"
       def graphQCardinal(nodeLabels: (String, String)): String => String =
@@ -97,8 +97,8 @@ object MermaidQ:
     SB1: SizeOf[B1],
     SA2: SizeOf[A2],
     SB2: SizeOf[B2],
-  ): MermaidQ[Binomial.Interface[A1, B1, A2, B2, _]] =
-    new MermaidQ[Binomial.Interface[A1, B1, A2, B2, _]]:
+  ): MermaidQ[Bi.Interface[A1, B1, A2, B2, _]] =
+    new MermaidQ[Bi.Interface[A1, B1, A2, B2, _]]:
       def graphQ[Y](p: String, nodeLabels: (String, String), paramLabelsQ: ((String, String), (String, String))): String =
         s"""|${nodeLabels._1}[A1]:::hidden---|${paramLabelsQ._1._1}
             |     |    |S${p}

--- a/modules/mermaid/shared/src/main/scala/polynomial/mermaid/render/q/MermaidQ.scala
+++ b/modules/mermaid/shared/src/main/scala/polynomial/mermaid/render/q/MermaidQ.scala
@@ -2,7 +2,8 @@ package polynomial.mermaid.render.q
 
 import polynomial.mermaid.Mermaid.ParamLabels
 import polynomial.mermaid.render.{Font, Render}
-import polynomial.`object`.{Bi, Mono}
+import polynomial.`object`.Binomial.BiInterface
+import polynomial.`object`.Monomial.Interface
 import typename.NameOf
 import typesize.SizeOf
 
@@ -32,8 +33,8 @@ object MermaidQ:
       NB: NameOf[B],
       SA: SizeOf[A],
       SB: SizeOf[B]
-    ): MermaidQ[Mono.Interface[A, B, _]] =
-    new MermaidQ[Mono.Interface[A, B, _]]:
+    ): MermaidQ[Interface[A, B, _]] =
+    new MermaidQ[Interface[A, B, _]]:
       def graphQ[Y](p: String, nodeLabels: (String, String), paramLabelsQ: (String, String)) =
         s"${nodeLabels._1}:::hidden---|${paramLabelsQ._1}|${p}---|${paramLabelsQ._2}|${nodeLabels._2}:::hidden;"
       def graphQCardinal(nodeLabels: (String, String)): String => String =
@@ -63,8 +64,8 @@ object MermaidQ:
       NB: NameOf[B],
       SA: SizeOf[A],
       SB: SizeOf[B]
-    ): MermaidQ[Mono.Interface[A, A => B, _]] =
-    new MermaidQ[Mono.Interface[A, A => B, _]]:
+    ): MermaidQ[Interface[A, A => B, _]] =
+    new MermaidQ[Interface[A, A => B, _]]:
       def graphQ[Y](p: String, nodeLabels: (String, String), paramLabelsQ: (String, String)) =
         s"${nodeLabels._1}:::hidden---|${paramLabelsQ._1}|${p}---|${paramLabelsQ._2}|${nodeLabels._2}:::hidden;"
       def graphQCardinal(nodeLabels: (String, String)): String => String =
@@ -97,8 +98,8 @@ object MermaidQ:
     SB1: SizeOf[B1],
     SA2: SizeOf[A2],
     SB2: SizeOf[B2],
-  ): MermaidQ[Bi.Interface[A1, B1, A2, B2, _]] =
-    new MermaidQ[Bi.Interface[A1, B1, A2, B2, _]]:
+  ): MermaidQ[BiInterface[A1, B1, A2, B2, _]] =
+    new MermaidQ[BiInterface[A1, B1, A2, B2, _]]:
       def graphQ[Y](p: String, nodeLabels: (String, String), paramLabelsQ: ((String, String), (String, String))): String =
         s"""|${nodeLabels._1}[A1]:::hidden---|${paramLabelsQ._1._1}
             |     |    |S${p}

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/PolyMap.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/PolyMap.scala
@@ -1,5 +1,6 @@
 package polynomial.morphism
 
+import cats.Id
 import polynomial.`object`.{Binomial, Monomial}
 import polynomial.product.{Tensor, Composition, ⊗}
 
@@ -11,7 +12,11 @@ abstract class PolyMap[P[_], Q[_], Y]:
 
 object PolyMap:
 
-  export polynomial.morphism.methods.andThen.*
+  export polynomial.morphism.methods.andThen.mS_bI.*
+  export polynomial.morphism.methods.andThen.mS_mI.*
+  export polynomial.morphism.methods.andThen.mSTensormS_bITensorbI.*
+  export polynomial.morphism.methods.andThen.mSTensormS_mITensormI.*
+  export polynomial.morphism.methods.andThen.mSTensormSTensorms_mITensormITensormI.*
   export polynomial.morphism.methods.swap.*
 
   def apply[P[_], Q[_], Y](
@@ -31,7 +36,8 @@ object PolyMap:
     case (PolyMap[p, q, Y], Monomial.Interface[a2, b2, Y])                              => Phi[p, Monomial.Interface[a2, b2, _], Y]
     case (PolyMap[o, p, Y], Tensor[q, r, Y])                                            => Phi[o, Tensor[q, r, _], Y]
     case (Monomial.Store[s, Y], Binomial.Interface[a1, b1, a2, b2, Y])                  => (s => b1, s => b2)
-    case (Monomial.Store[s, Y], Monomial.Interface[a, b, Y])                            => s => b
+    // case (Monomial.Store[s, Y], Monomial.Interface[a, b, Y])                            => s => b
+    case (Monomial.Store[s, Y], Monomial.Interface[a, b, Y])                            => Tambara[s, b]
     case (Monomial.Store[s, Y], Composition[p, q, Y])                                   => (Phi[Monomial.Store[s, _], p, Y], Phi[p, q, Y])
     case (Tensor[p, q, Y], Monomial.Store[s1, Y])                                       => Phi[Tensor.DayConvolution[p, q, _], Monomial.Store[s1, _], Y]
     case (Tensor[p, q, Y], Monomial.Interface[a1, b1, Y])                               => Phi[Tensor.DayConvolution[p, q, _], Monomial.Interface[a1, b1, _], Y]
@@ -44,7 +50,8 @@ object PolyMap:
     case (Monomial.Interface[a1, b1, Y], Binomial.Interface[a2, b2, a3, b3, Y])         => ((b1, a2) => a1, (b1, a3) => a1)
     case (Monomial.Interface[a1, b1, Y], Monomial.Interface[a2, b2, Y])                 => (b1, a2) => a1
     case (Monomial.Store[s, Y], Binomial.Interface[a1, b1, a2, b2, Y])                  => ((s, a1) => s, (s, a2) => s)
-    case (Monomial.Store[s, Y], Monomial.Interface[a, b, Y])                            => (s, a) => s
+    // case (Monomial.Store[s, Y], Monomial.Interface[a, b, Y])                            => (s, a) => s
+    case (Monomial.Store[s, Y], Monomial.Interface[a, b, Y])                            => TambaraSharp[s, a]
     case (Monomial.Store[s, Y], Composition[p, q, Y])                                   => (s, Composition.DecomposeSharp[p, q, Y]) => s
     case (PolyMap[p, q, Y], Binomial.Interface[a3, b3, a4, b4, Y])                      => PhiSharp[p, Binomial.Interface[a3, b3, a4, b4, _], Y]
     case (PolyMap[p, q, Y], Monomial.Interface[a2, b2, Y])                              => PhiSharp[p, Monomial.Interface[a2, b2, _], Y]
@@ -53,3 +60,18 @@ object PolyMap:
     case (Tensor[p, q, Y], Monomial.Interface[a1, b1, Y])                               => PhiSharp[Tensor.DayConvolution[p, q, _], Monomial.Interface[a1, b1, _], Y]
     case (Tensor[p, q, Y], Monomial.Store[s1, Y])                                       => PhiSharp[Tensor.DayConvolution[p, q, _], Monomial.Store[s1, _], Y]
     case (Tensor[o, p, Y], Tensor[q, r, Y])                                             => PhiSharp[Tensor.DayConvolution[o, p, _], Tensor.DayConvolution[q, r, _], Y]
+
+  type Tambara[S, B] = (S, B) match
+    // case ((c, t), B) => S => (c, B)
+    // case (Either[c, t], B) => S => Either[t, B]
+    case (Id[s], Id[b]) => s => b
+    case (Option[s], Id[b]) => Option[s] => b
+    case (Option[s], Option[b]) => Option[s] => Option[b]
+    // case (S, B) => S => B
+
+
+  type TambaraSharp[S, A] = (S, A) match
+    // case ((c, t), A) => (S, (A, c)) => S
+    // case (Option[s], A) => (S, Option[A]) => Option[s]
+    // case (Either[c, t], A) => (S, Either[t, A]) => t
+    case (Id[s], A) => (s, A) => s 

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/PolyMap.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/PolyMap.scala
@@ -29,35 +29,35 @@ object PolyMap:
 
   type Phi[P[_], Q[_], Y] = (P[Y], Q[Y]) match
     case (Bi.Interface[a1, b1, a2, b2, Y], Bi.Interface[a3, b3, a4, b4, Y]) => (b1 => b3, b2 => b4)
-    case (Bi.Interface[a1, b1, a2, b2, Y], Mono.Interface[a3, b3, Y])         => (b1 => b3, b2 => b3)
-    case (Mono.Interface[a1, b1, Y], Bi.Interface[a3, b3, a4, b4, Y])         => (b1 => b3, b1 => b4)
-    case (Mono.Interface[a1, b1, Y], Mono.Interface[a2, b2, Y])                 => b1 => b2
-    case (PolyMap[p, q, Y], Bi.Interface[a3, b3, a4, b4, Y])                      => Phi[p, Bi.Interface[a3, b3, a4, b4, _], Y]
-    case (PolyMap[p, q, Y], Mono.Interface[a2, b2, Y])                              => Phi[p, Mono.Interface[a2, b2, _], Y]
-    case (PolyMap[o, p, Y], Tensor[q, r, Y])                                            => Phi[o, Tensor[q, r, _], Y]
-    case (Mono.Store[s, Y], Bi.Interface[a1, b1, a2, b2, Y])                  => (s => b1, s => b2)
-    case (Mono.Store[s, Y], Mono.Interface[a, b, Y])                            => Tambara[s, b]
-    case (Mono.Store[s, Y], Composition[p, q, Y])                                   => (Phi[Mono.Store[s, _], p, Y], Phi[p, q, Y])
-    case (Tensor[p, q, Y], Mono.Store[s1, Y])                                       => Phi[Tensor.DayConvolution[p, q, _], Mono.Store[s1, _], Y]
-    case (Tensor[p, q, Y], Mono.Interface[a1, b1, Y])                               => Phi[Tensor.DayConvolution[p, q, _], Mono.Interface[a1, b1, _], Y]
-    case (Tensor[p, q, Y], Bi.Interface[a1, b1, a2, b2, Y])                       => Phi[Tensor.DayConvolution[p, q, _], Bi.Interface[a1, b1, a2, b2, _], Y]
-    case (Tensor[o, p, Y], Tensor[q, r, Y])                                             => Phi[Tensor.DayConvolution[o, p, _], Tensor.DayConvolution[q, r, _], Y]
+    case (Bi.Interface[a1, b1, a2, b2, Y], Mono.Interface[a3, b3, Y])       => (b1 => b3, b2 => b3)
+    case (Mono.Interface[a1, b1, Y], Bi.Interface[a3, b3, a4, b4, Y])       => (b1 => b3, b1 => b4)
+    case (Mono.Interface[a1, b1, Y], Mono.Interface[a2, b2, Y])             => b1 => b2
+    case (PolyMap[p, q, Y], Bi.Interface[a3, b3, a4, b4, Y])                => Phi[p, Bi.Interface[a3, b3, a4, b4, _], Y]
+    case (PolyMap[p, q, Y], Mono.Interface[a2, b2, Y])                      => Phi[p, Mono.Interface[a2, b2, _], Y]
+    case (PolyMap[o, p, Y], Tensor[q, r, Y])                                => Phi[o, Tensor[q, r, _], Y]
+    case (Mono.Store[s, Y], Bi.Interface[a1, b1, a2, b2, Y])                => (s => b1, s => b2)
+    case (Mono.Store[s, Y], Mono.Interface[a, b, Y])                        => Tambara[s, b]
+    case (Mono.Store[s, Y], Composition[p, q, Y])                           => (Phi[Mono.Store[s, _], p, Y], Phi[p, q, Y])
+    case (Tensor[p, q, Y], Mono.Store[s1, Y])                               => Phi[Tensor.DayConvolution[p, q, _], Mono.Store[s1, _], Y]
+    case (Tensor[p, q, Y], Mono.Interface[a1, b1, Y])                       => Phi[Tensor.DayConvolution[p, q, _], Mono.Interface[a1, b1, _], Y]
+    case (Tensor[p, q, Y], Bi.Interface[a1, b1, a2, b2, Y])                 => Phi[Tensor.DayConvolution[p, q, _], Bi.Interface[a1, b1, a2, b2, _], Y]
+    case (Tensor[o, p, Y], Tensor[q, r, Y])                                 => Phi[Tensor.DayConvolution[o, p, _], Tensor.DayConvolution[q, r, _], Y]
 
   type PhiSharp[P[_], Q[_], Y] = (P[Y], Q[Y]) match
     case (Bi.Interface[a1, b1, a2, b2, Y], Bi.Interface[a3, b3, a4, b4, Y]) => ((b1, a3) => a1, (b2, a4) => a2)
-    case (Bi.Interface[a1, b1, a2, b2, Y], Mono.Interface[a3, b3, Y])         => ((b1, a3) => a1, (b2, a3) => a2)
-    case (Mono.Interface[a1, b1, Y], Bi.Interface[a2, b2, a3, b3, Y])         => ((b1, a2) => a1, (b1, a3) => a1)
-    case (Mono.Interface[a1, b1, Y], Mono.Interface[a2, b2, Y])                 => (b1, a2) => a1
-    case (Mono.Store[s, Y], Bi.Interface[a1, b1, a2, b2, Y])                  => ((s, a1) => s, (s, a2) => s)
-    case (Mono.Store[s, Y], Mono.Interface[a, b, Y])                            => TambaraSharp[s, a]
-    case (Mono.Store[s, Y], Composition[p, q, Y])                                   => (s, Composition.DecomposeSharp[p, q, Y]) => s
-    case (PolyMap[p, q, Y], Bi.Interface[a3, b3, a4, b4, Y])                      => PhiSharp[p, Bi.Interface[a3, b3, a4, b4, _], Y]
-    case (PolyMap[p, q, Y], Mono.Interface[a2, b2, Y])                              => PhiSharp[p, Mono.Interface[a2, b2, _], Y]
-    case (PolyMap[o, p, Y], Tensor[q, r, Y])                                            => PhiSharp[o, Tensor[q, r, _], Y]
-    case (Tensor[p, q, Y], Bi.Interface[a1, b1, a2, b2, Y])                       => PhiSharp[Tensor.DayConvolution[p, q, _], Bi.Interface[a1, b1, a2, b2, _], Y]
-    case (Tensor[p, q, Y], Mono.Interface[a1, b1, Y])                               => PhiSharp[Tensor.DayConvolution[p, q, _], Mono.Interface[a1, b1, _], Y]
-    case (Tensor[p, q, Y], Mono.Store[s1, Y])                                       => PhiSharp[Tensor.DayConvolution[p, q, _], Mono.Store[s1, _], Y]
-    case (Tensor[o, p, Y], Tensor[q, r, Y])                                             => PhiSharp[Tensor.DayConvolution[o, p, _], Tensor.DayConvolution[q, r, _], Y]
+    case (Bi.Interface[a1, b1, a2, b2, Y], Mono.Interface[a3, b3, Y])       => ((b1, a3) => a1, (b2, a3) => a2)
+    case (Mono.Interface[a1, b1, Y], Bi.Interface[a2, b2, a3, b3, Y])       => ((b1, a2) => a1, (b1, a3) => a1)
+    case (Mono.Interface[a1, b1, Y], Mono.Interface[a2, b2, Y])             => (b1, a2) => a1
+    case (Mono.Store[s, Y], Bi.Interface[a1, b1, a2, b2, Y])                => ((s, a1) => s, (s, a2) => s)
+    case (Mono.Store[s, Y], Mono.Interface[a, b, Y])                        => TambaraSharp[s, a]
+    case (Mono.Store[s, Y], Composition[p, q, Y])                           => (s, Composition.DecomposeSharp[p, q, Y]) => s
+    case (PolyMap[p, q, Y], Bi.Interface[a3, b3, a4, b4, Y])                => PhiSharp[p, Bi.Interface[a3, b3, a4, b4, _], Y]
+    case (PolyMap[p, q, Y], Mono.Interface[a2, b2, Y])                      => PhiSharp[p, Mono.Interface[a2, b2, _], Y]
+    case (PolyMap[o, p, Y], Tensor[q, r, Y])                                => PhiSharp[o, Tensor[q, r, _], Y]
+    case (Tensor[p, q, Y], Bi.Interface[a1, b1, a2, b2, Y])                 => PhiSharp[Tensor.DayConvolution[p, q, _], Bi.Interface[a1, b1, a2, b2, _], Y]
+    case (Tensor[p, q, Y], Mono.Interface[a1, b1, Y])                       => PhiSharp[Tensor.DayConvolution[p, q, _], Mono.Interface[a1, b1, _], Y]
+    case (Tensor[p, q, Y], Mono.Store[s1, Y])                               => PhiSharp[Tensor.DayConvolution[p, q, _], Mono.Store[s1, _], Y]
+    case (Tensor[o, p, Y], Tensor[q, r, Y])                                 => PhiSharp[Tensor.DayConvolution[o, p, _], Tensor.DayConvolution[q, r, _], Y]
 
   type Tambara[S, B] = (S, B) match
     case (Id[s], Id[b]) => s => b

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/PolyMap.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/PolyMap.scala
@@ -2,7 +2,7 @@ package polynomial.morphism
 
 import cats.Id
 import polynomial.`object`.{Bi, Mono}
-import polynomial.product.{Tensor, Composition, ⊗}
+import polynomial.product.{Tensor, Composition}
 
 type ~>[P[_], Q[_]] = PolyMap[P, Q, _]
 

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/PolyMap.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/PolyMap.scala
@@ -1,7 +1,7 @@
 package polynomial.morphism
 
 import cats.Id
-import polynomial.`object`.{Binomial, Monomial}
+import polynomial.`object`.{Bi, Mono}
 import polynomial.product.{Tensor, Composition, ⊗}
 
 type ~>[P[_], Q[_]] = PolyMap[P, Q, _]
@@ -28,35 +28,35 @@ object PolyMap:
       def `φ#`: PhiSharp[P, Q, Y] = phiSharp
 
   type Phi[P[_], Q[_], Y] = (P[Y], Q[Y]) match
-    case (Binomial.Interface[a1, b1, a2, b2, Y], Binomial.Interface[a3, b3, a4, b4, Y]) => (b1 => b3, b2 => b4)
-    case (Binomial.Interface[a1, b1, a2, b2, Y], Monomial.Interface[a3, b3, Y])         => (b1 => b3, b2 => b3)
-    case (Monomial.Interface[a1, b1, Y], Binomial.Interface[a3, b3, a4, b4, Y])         => (b1 => b3, b1 => b4)
-    case (Monomial.Interface[a1, b1, Y], Monomial.Interface[a2, b2, Y])                 => b1 => b2
-    case (PolyMap[p, q, Y], Binomial.Interface[a3, b3, a4, b4, Y])                      => Phi[p, Binomial.Interface[a3, b3, a4, b4, _], Y]
-    case (PolyMap[p, q, Y], Monomial.Interface[a2, b2, Y])                              => Phi[p, Monomial.Interface[a2, b2, _], Y]
+    case (Bi.Interface[a1, b1, a2, b2, Y], Bi.Interface[a3, b3, a4, b4, Y]) => (b1 => b3, b2 => b4)
+    case (Bi.Interface[a1, b1, a2, b2, Y], Mono.Interface[a3, b3, Y])         => (b1 => b3, b2 => b3)
+    case (Mono.Interface[a1, b1, Y], Bi.Interface[a3, b3, a4, b4, Y])         => (b1 => b3, b1 => b4)
+    case (Mono.Interface[a1, b1, Y], Mono.Interface[a2, b2, Y])                 => b1 => b2
+    case (PolyMap[p, q, Y], Bi.Interface[a3, b3, a4, b4, Y])                      => Phi[p, Bi.Interface[a3, b3, a4, b4, _], Y]
+    case (PolyMap[p, q, Y], Mono.Interface[a2, b2, Y])                              => Phi[p, Mono.Interface[a2, b2, _], Y]
     case (PolyMap[o, p, Y], Tensor[q, r, Y])                                            => Phi[o, Tensor[q, r, _], Y]
-    case (Monomial.Store[s, Y], Binomial.Interface[a1, b1, a2, b2, Y])                  => (s => b1, s => b2)
-    case (Monomial.Store[s, Y], Monomial.Interface[a, b, Y])                            => Tambara[s, b]
-    case (Monomial.Store[s, Y], Composition[p, q, Y])                                   => (Phi[Monomial.Store[s, _], p, Y], Phi[p, q, Y])
-    case (Tensor[p, q, Y], Monomial.Store[s1, Y])                                       => Phi[Tensor.DayConvolution[p, q, _], Monomial.Store[s1, _], Y]
-    case (Tensor[p, q, Y], Monomial.Interface[a1, b1, Y])                               => Phi[Tensor.DayConvolution[p, q, _], Monomial.Interface[a1, b1, _], Y]
-    case (Tensor[p, q, Y], Binomial.Interface[a1, b1, a2, b2, Y])                       => Phi[Tensor.DayConvolution[p, q, _], Binomial.Interface[a1, b1, a2, b2, _], Y]
+    case (Mono.Store[s, Y], Bi.Interface[a1, b1, a2, b2, Y])                  => (s => b1, s => b2)
+    case (Mono.Store[s, Y], Mono.Interface[a, b, Y])                            => Tambara[s, b]
+    case (Mono.Store[s, Y], Composition[p, q, Y])                                   => (Phi[Mono.Store[s, _], p, Y], Phi[p, q, Y])
+    case (Tensor[p, q, Y], Mono.Store[s1, Y])                                       => Phi[Tensor.DayConvolution[p, q, _], Mono.Store[s1, _], Y]
+    case (Tensor[p, q, Y], Mono.Interface[a1, b1, Y])                               => Phi[Tensor.DayConvolution[p, q, _], Mono.Interface[a1, b1, _], Y]
+    case (Tensor[p, q, Y], Bi.Interface[a1, b1, a2, b2, Y])                       => Phi[Tensor.DayConvolution[p, q, _], Bi.Interface[a1, b1, a2, b2, _], Y]
     case (Tensor[o, p, Y], Tensor[q, r, Y])                                             => Phi[Tensor.DayConvolution[o, p, _], Tensor.DayConvolution[q, r, _], Y]
 
   type PhiSharp[P[_], Q[_], Y] = (P[Y], Q[Y]) match
-    case (Binomial.Interface[a1, b1, a2, b2, Y], Binomial.Interface[a3, b3, a4, b4, Y]) => ((b1, a3) => a1, (b2, a4) => a2)
-    case (Binomial.Interface[a1, b1, a2, b2, Y], Monomial.Interface[a3, b3, Y])         => ((b1, a3) => a1, (b2, a3) => a2)
-    case (Monomial.Interface[a1, b1, Y], Binomial.Interface[a2, b2, a3, b3, Y])         => ((b1, a2) => a1, (b1, a3) => a1)
-    case (Monomial.Interface[a1, b1, Y], Monomial.Interface[a2, b2, Y])                 => (b1, a2) => a1
-    case (Monomial.Store[s, Y], Binomial.Interface[a1, b1, a2, b2, Y])                  => ((s, a1) => s, (s, a2) => s)
-    case (Monomial.Store[s, Y], Monomial.Interface[a, b, Y])                            => TambaraSharp[s, a]
-    case (Monomial.Store[s, Y], Composition[p, q, Y])                                   => (s, Composition.DecomposeSharp[p, q, Y]) => s
-    case (PolyMap[p, q, Y], Binomial.Interface[a3, b3, a4, b4, Y])                      => PhiSharp[p, Binomial.Interface[a3, b3, a4, b4, _], Y]
-    case (PolyMap[p, q, Y], Monomial.Interface[a2, b2, Y])                              => PhiSharp[p, Monomial.Interface[a2, b2, _], Y]
+    case (Bi.Interface[a1, b1, a2, b2, Y], Bi.Interface[a3, b3, a4, b4, Y]) => ((b1, a3) => a1, (b2, a4) => a2)
+    case (Bi.Interface[a1, b1, a2, b2, Y], Mono.Interface[a3, b3, Y])         => ((b1, a3) => a1, (b2, a3) => a2)
+    case (Mono.Interface[a1, b1, Y], Bi.Interface[a2, b2, a3, b3, Y])         => ((b1, a2) => a1, (b1, a3) => a1)
+    case (Mono.Interface[a1, b1, Y], Mono.Interface[a2, b2, Y])                 => (b1, a2) => a1
+    case (Mono.Store[s, Y], Bi.Interface[a1, b1, a2, b2, Y])                  => ((s, a1) => s, (s, a2) => s)
+    case (Mono.Store[s, Y], Mono.Interface[a, b, Y])                            => TambaraSharp[s, a]
+    case (Mono.Store[s, Y], Composition[p, q, Y])                                   => (s, Composition.DecomposeSharp[p, q, Y]) => s
+    case (PolyMap[p, q, Y], Bi.Interface[a3, b3, a4, b4, Y])                      => PhiSharp[p, Bi.Interface[a3, b3, a4, b4, _], Y]
+    case (PolyMap[p, q, Y], Mono.Interface[a2, b2, Y])                              => PhiSharp[p, Mono.Interface[a2, b2, _], Y]
     case (PolyMap[o, p, Y], Tensor[q, r, Y])                                            => PhiSharp[o, Tensor[q, r, _], Y]
-    case (Tensor[p, q, Y], Binomial.Interface[a1, b1, a2, b2, Y])                       => PhiSharp[Tensor.DayConvolution[p, q, _], Binomial.Interface[a1, b1, a2, b2, _], Y]
-    case (Tensor[p, q, Y], Monomial.Interface[a1, b1, Y])                               => PhiSharp[Tensor.DayConvolution[p, q, _], Monomial.Interface[a1, b1, _], Y]
-    case (Tensor[p, q, Y], Monomial.Store[s1, Y])                                       => PhiSharp[Tensor.DayConvolution[p, q, _], Monomial.Store[s1, _], Y]
+    case (Tensor[p, q, Y], Bi.Interface[a1, b1, a2, b2, Y])                       => PhiSharp[Tensor.DayConvolution[p, q, _], Bi.Interface[a1, b1, a2, b2, _], Y]
+    case (Tensor[p, q, Y], Mono.Interface[a1, b1, Y])                               => PhiSharp[Tensor.DayConvolution[p, q, _], Mono.Interface[a1, b1, _], Y]
+    case (Tensor[p, q, Y], Mono.Store[s1, Y])                                       => PhiSharp[Tensor.DayConvolution[p, q, _], Mono.Store[s1, _], Y]
     case (Tensor[o, p, Y], Tensor[q, r, Y])                                             => PhiSharp[Tensor.DayConvolution[o, p, _], Tensor.DayConvolution[q, r, _], Y]
 
   type Tambara[S, B] = (S, B) match

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/PolyMap.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/PolyMap.scala
@@ -1,7 +1,8 @@
 package polynomial.morphism
 
 import cats.Id
-import polynomial.`object`.{Bi, Mono}
+import polynomial.`object`.Binomial.BiInterface
+import polynomial.`object`.Monomial.{Interface, Store}
 import polynomial.product.{Tensor, Composition}
 
 type ~>[P[_], Q[_]] = PolyMap[P, Q, _]
@@ -28,40 +29,40 @@ object PolyMap:
       def `φ#`: PhiSharp[P, Q, Y] = phiSharp
 
   type Phi[P[_], Q[_], Y] = (P[Y], Q[Y]) match
-    case (Bi.Interface[a1, b1, a2, b2, Y], Bi.Interface[a3, b3, a4, b4, Y]) => (b1 => b3, b2 => b4)
-    case (Bi.Interface[a1, b1, a2, b2, Y], Mono.Interface[a3, b3, Y])       => (b1 => b3, b2 => b3)
-    case (Mono.Interface[a1, b1, Y], Bi.Interface[a3, b3, a4, b4, Y])       => (b1 => b3, b1 => b4)
-    case (Mono.Interface[a1, b1, Y], Mono.Interface[a2, b2, Y])             => b1 => b2
-    case (PolyMap[p, q, Y], Bi.Interface[a3, b3, a4, b4, Y])                => Phi[p, Bi.Interface[a3, b3, a4, b4, _], Y]
-    case (PolyMap[p, q, Y], Mono.Interface[a2, b2, Y])                      => Phi[p, Mono.Interface[a2, b2, _], Y]
-    case (PolyMap[o, p, Y], Tensor[q, r, Y])                                => Phi[o, Tensor[q, r, _], Y]
-    case (Mono.Store[s, Y], Bi.Interface[a1, b1, a2, b2, Y])                => (s => b1, s => b2)
-    case (Mono.Store[s, Y], Mono.Interface[a, b, Y])                        => Tambara[s, b]
-    case (Mono.Store[s, Y], Composition[p, q, Y])                           => (Phi[Mono.Store[s, _], p, Y], Phi[p, q, Y])
-    case (Tensor[p, q, Y], Mono.Store[s1, Y])                               => Phi[Tensor.DayConvolution[p, q, _], Mono.Store[s1, _], Y]
-    case (Tensor[p, q, Y], Mono.Interface[a1, b1, Y])                       => Phi[Tensor.DayConvolution[p, q, _], Mono.Interface[a1, b1, _], Y]
-    case (Tensor[p, q, Y], Bi.Interface[a1, b1, a2, b2, Y])                 => Phi[Tensor.DayConvolution[p, q, _], Bi.Interface[a1, b1, a2, b2, _], Y]
-    case (Tensor[o, p, Y], Tensor[q, r, Y])                                 => Phi[Tensor.DayConvolution[o, p, _], Tensor.DayConvolution[q, r, _], Y]
+    case (BiInterface[a1, b1, a2, b2, Y], BiInterface[a3, b3, a4, b4, Y]) => (b1 => b3, b2 => b4)
+    case (BiInterface[a1, b1, a2, b2, Y], Interface[a3, b3, Y])           => (b1 => b3, b2 => b3)
+    case (Interface[a1, b1, Y], BiInterface[a3, b3, a4, b4, Y])           => (b1 => b3, b1 => b4)
+    case (Interface[a1, b1, Y], Interface[a2, b2, Y])                     => b1 => b2
+    case (PolyMap[p, q, Y], BiInterface[a3, b3, a4, b4, Y])               => Phi[p, BiInterface[a3, b3, a4, b4, _], Y]
+    case (PolyMap[p, q, Y], Interface[a2, b2, Y])                         => Phi[p, Interface[a2, b2, _], Y]
+    case (PolyMap[o, p, Y], Tensor[q, r, Y])                              => Phi[o, Tensor[q, r, _], Y]
+    case (Store[s, Y], BiInterface[a1, b1, a2, b2, Y])                    => (s => b1, s => b2)
+    case (Store[s, Y], Interface[a, b, Y])                                => Tambara[s, b]
+    case (Store[s, Y], Composition[p, q, Y])                              => (Phi[Store[s, _], p, Y], Phi[p, q, Y])
+    case (Tensor[p, q, Y], Store[s1, Y])                                  => Phi[Tensor.DayConvolution[p, q, _], Store[s1, _], Y]
+    case (Tensor[p, q, Y], Interface[a1, b1, Y])                          => Phi[Tensor.DayConvolution[p, q, _], Interface[a1, b1, _], Y]
+    case (Tensor[p, q, Y], BiInterface[a1, b1, a2, b2, Y])                => Phi[Tensor.DayConvolution[p, q, _], BiInterface[a1, b1, a2, b2, _], Y]
+    case (Tensor[o, p, Y], Tensor[q, r, Y])                               => Phi[Tensor.DayConvolution[o, p, _], Tensor.DayConvolution[q, r, _], Y]
 
   type PhiSharp[P[_], Q[_], Y] = (P[Y], Q[Y]) match
-    case (Bi.Interface[a1, b1, a2, b2, Y], Bi.Interface[a3, b3, a4, b4, Y]) => ((b1, a3) => a1, (b2, a4) => a2)
-    case (Bi.Interface[a1, b1, a2, b2, Y], Mono.Interface[a3, b3, Y])       => ((b1, a3) => a1, (b2, a3) => a2)
-    case (Mono.Interface[a1, b1, Y], Bi.Interface[a2, b2, a3, b3, Y])       => ((b1, a2) => a1, (b1, a3) => a1)
-    case (Mono.Interface[a1, b1, Y], Mono.Interface[a2, b2, Y])             => (b1, a2) => a1
-    case (Mono.Store[s, Y], Bi.Interface[a1, b1, a2, b2, Y])                => ((s, a1) => s, (s, a2) => s)
-    case (Mono.Store[s, Y], Mono.Interface[a, b, Y])                        => TambaraSharp[s, a]
-    case (Mono.Store[s, Y], Composition[p, q, Y])                           => (s, Composition.DecomposeSharp[p, q, Y]) => s
-    case (PolyMap[p, q, Y], Bi.Interface[a3, b3, a4, b4, Y])                => PhiSharp[p, Bi.Interface[a3, b3, a4, b4, _], Y]
-    case (PolyMap[p, q, Y], Mono.Interface[a2, b2, Y])                      => PhiSharp[p, Mono.Interface[a2, b2, _], Y]
-    case (PolyMap[o, p, Y], Tensor[q, r, Y])                                => PhiSharp[o, Tensor[q, r, _], Y]
-    case (Tensor[p, q, Y], Bi.Interface[a1, b1, a2, b2, Y])                 => PhiSharp[Tensor.DayConvolution[p, q, _], Bi.Interface[a1, b1, a2, b2, _], Y]
-    case (Tensor[p, q, Y], Mono.Interface[a1, b1, Y])                       => PhiSharp[Tensor.DayConvolution[p, q, _], Mono.Interface[a1, b1, _], Y]
-    case (Tensor[p, q, Y], Mono.Store[s1, Y])                               => PhiSharp[Tensor.DayConvolution[p, q, _], Mono.Store[s1, _], Y]
-    case (Tensor[o, p, Y], Tensor[q, r, Y])                                 => PhiSharp[Tensor.DayConvolution[o, p, _], Tensor.DayConvolution[q, r, _], Y]
+    case (BiInterface[a1, b1, a2, b2, Y], BiInterface[a3, b3, a4, b4, Y]) => ((b1, a3) => a1, (b2, a4) => a2)
+    case (BiInterface[a1, b1, a2, b2, Y], Interface[a3, b3, Y])           => ((b1, a3) => a1, (b2, a3) => a2)
+    case (Interface[a1, b1, Y], BiInterface[a2, b2, a3, b3, Y])           => ((b1, a2) => a1, (b1, a3) => a1)
+    case (Interface[a1, b1, Y], Interface[a2, b2, Y])                     => (b1, a2) => a1
+    case (Store[s, Y], BiInterface[a1, b1, a2, b2, Y])                    => ((s, a1) => s, (s, a2) => s)
+    case (Store[s, Y], Interface[a, b, Y])                                => TambaraSharp[s, a]
+    case (Store[s, Y], Composition[p, q, Y])                              => (s, Composition.DecomposeSharp[p, q, Y]) => s
+    case (PolyMap[p, q, Y], BiInterface[a3, b3, a4, b4, Y])               => PhiSharp[p, BiInterface[a3, b3, a4, b4, _], Y]
+    case (PolyMap[p, q, Y], Interface[a2, b2, Y])                         => PhiSharp[p, Interface[a2, b2, _], Y]
+    case (PolyMap[o, p, Y], Tensor[q, r, Y])                              => PhiSharp[o, Tensor[q, r, _], Y]
+    case (Tensor[p, q, Y], BiInterface[a1, b1, a2, b2, Y])                => PhiSharp[Tensor.DayConvolution[p, q, _], BiInterface[a1, b1, a2, b2, _], Y]
+    case (Tensor[p, q, Y], Interface[a1, b1, Y])                          => PhiSharp[Tensor.DayConvolution[p, q, _], Interface[a1, b1, _], Y]
+    case (Tensor[p, q, Y], Store[s1, Y])                                  => PhiSharp[Tensor.DayConvolution[p, q, _], Store[s1, _], Y]
+    case (Tensor[o, p, Y], Tensor[q, r, Y])                               => PhiSharp[Tensor.DayConvolution[o, p, _], Tensor.DayConvolution[q, r, _], Y]
 
   type Tambara[S, B] = (S, B) match
-    case (Id[s], Id[b]) => s => b
-    case (Option[s], Id[b]) => Option[s] => b
+    case (Id[s], Id[b])         => s => b
+    case (Option[s], Id[b])     => Option[s] => b
     case (Option[s], Option[b]) => Option[s] => Option[b]
 
   type TambaraSharp[S, A] = (S, A) match

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/PolyMap.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/PolyMap.scala
@@ -37,7 +37,7 @@ object PolyMap:
     case (PolyMap[p, q, Y], Interface[a2, b2, Y])                         => Phi[p, Interface[a2, b2, _], Y]
     case (PolyMap[o, p, Y], Tensor[q, r, Y])                              => Phi[o, Tensor[q, r, _], Y]
     case (Store[s, Y], BiInterface[a1, b1, a2, b2, Y])                    => (s => b1, s => b2)
-    case (Store[s, Y], Interface[a, b, Y])                                => Tambara[s, b]
+    case (Store[s, Y], Interface[a, b, Y])                                => s => b
     case (Store[s, Y], Composition[p, q, Y])                              => (Phi[Store[s, _], p, Y], Phi[p, q, Y])
     case (Tensor[p, q, Y], Store[s1, Y])                                  => Phi[Tensor.DayConvolution[p, q, _], Store[s1, _], Y]
     case (Tensor[p, q, Y], Interface[a1, b1, Y])                          => Phi[Tensor.DayConvolution[p, q, _], Interface[a1, b1, _], Y]
@@ -50,7 +50,7 @@ object PolyMap:
     case (Interface[a1, b1, Y], BiInterface[a2, b2, a3, b3, Y])           => ((b1, a2) => a1, (b1, a3) => a1)
     case (Interface[a1, b1, Y], Interface[a2, b2, Y])                     => (b1, a2) => a1
     case (Store[s, Y], BiInterface[a1, b1, a2, b2, Y])                    => ((s, a1) => s, (s, a2) => s)
-    case (Store[s, Y], Interface[a, b, Y])                                => TambaraSharp[s, a]
+    case (Store[s, Y], Interface[a, b, Y])                                => (s, a) => s
     case (Store[s, Y], Composition[p, q, Y])                              => (s, Composition.DecomposeSharp[p, q, Y]) => s
     case (PolyMap[p, q, Y], BiInterface[a3, b3, a4, b4, Y])               => PhiSharp[p, BiInterface[a3, b3, a4, b4, _], Y]
     case (PolyMap[p, q, Y], Interface[a2, b2, Y])                         => PhiSharp[p, Interface[a2, b2, _], Y]
@@ -59,11 +59,3 @@ object PolyMap:
     case (Tensor[p, q, Y], Interface[a1, b1, Y])                          => PhiSharp[Tensor.DayConvolution[p, q, _], Interface[a1, b1, _], Y]
     case (Tensor[p, q, Y], Store[s1, Y])                                  => PhiSharp[Tensor.DayConvolution[p, q, _], Store[s1, _], Y]
     case (Tensor[o, p, Y], Tensor[q, r, Y])                               => PhiSharp[Tensor.DayConvolution[o, p, _], Tensor.DayConvolution[q, r, _], Y]
-
-  type Tambara[S, B] = (S, B) match
-    case (Id[s], Id[b])         => s => b
-    case (Option[s], Id[b])     => Option[s] => b
-    case (Option[s], Option[b]) => Option[s] => Option[b]
-
-  type TambaraSharp[S, A] = (S, A) match
-    case (Id[s], A) => (s, A) => s 

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/PolyMap.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/PolyMap.scala
@@ -36,7 +36,6 @@ object PolyMap:
     case (PolyMap[p, q, Y], Monomial.Interface[a2, b2, Y])                              => Phi[p, Monomial.Interface[a2, b2, _], Y]
     case (PolyMap[o, p, Y], Tensor[q, r, Y])                                            => Phi[o, Tensor[q, r, _], Y]
     case (Monomial.Store[s, Y], Binomial.Interface[a1, b1, a2, b2, Y])                  => (s => b1, s => b2)
-    // case (Monomial.Store[s, Y], Monomial.Interface[a, b, Y])                            => s => b
     case (Monomial.Store[s, Y], Monomial.Interface[a, b, Y])                            => Tambara[s, b]
     case (Monomial.Store[s, Y], Composition[p, q, Y])                                   => (Phi[Monomial.Store[s, _], p, Y], Phi[p, q, Y])
     case (Tensor[p, q, Y], Monomial.Store[s1, Y])                                       => Phi[Tensor.DayConvolution[p, q, _], Monomial.Store[s1, _], Y]
@@ -50,7 +49,6 @@ object PolyMap:
     case (Monomial.Interface[a1, b1, Y], Binomial.Interface[a2, b2, a3, b3, Y])         => ((b1, a2) => a1, (b1, a3) => a1)
     case (Monomial.Interface[a1, b1, Y], Monomial.Interface[a2, b2, Y])                 => (b1, a2) => a1
     case (Monomial.Store[s, Y], Binomial.Interface[a1, b1, a2, b2, Y])                  => ((s, a1) => s, (s, a2) => s)
-    // case (Monomial.Store[s, Y], Monomial.Interface[a, b, Y])                            => (s, a) => s
     case (Monomial.Store[s, Y], Monomial.Interface[a, b, Y])                            => TambaraSharp[s, a]
     case (Monomial.Store[s, Y], Composition[p, q, Y])                                   => (s, Composition.DecomposeSharp[p, q, Y]) => s
     case (PolyMap[p, q, Y], Binomial.Interface[a3, b3, a4, b4, Y])                      => PhiSharp[p, Binomial.Interface[a3, b3, a4, b4, _], Y]
@@ -62,16 +60,9 @@ object PolyMap:
     case (Tensor[o, p, Y], Tensor[q, r, Y])                                             => PhiSharp[Tensor.DayConvolution[o, p, _], Tensor.DayConvolution[q, r, _], Y]
 
   type Tambara[S, B] = (S, B) match
-    // case ((c, t), B) => S => (c, B)
-    // case (Either[c, t], B) => S => Either[t, B]
     case (Id[s], Id[b]) => s => b
     case (Option[s], Id[b]) => Option[s] => b
     case (Option[s], Option[b]) => Option[s] => Option[b]
-    // case (S, B) => S => B
-
 
   type TambaraSharp[S, A] = (S, A) match
-    // case ((c, t), A) => (S, (A, c)) => S
-    // case (Option[s], A) => (S, Option[A]) => Option[s]
-    // case (Either[c, t], A) => (S, Either[t, A]) => t
     case (Id[s], A) => (s, A) => s 

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen.scala
@@ -100,18 +100,13 @@ object andThen:
             (s, a) => p.`φ#`._2(s, w.`φ#`._2(p.φ._2(s), a)),
           )
 
-  extension [S1, S2, S3, A1, B1, A2, B2, A3, B3, A4, B4, Y] (
-    p: PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), Y]
-  )
+  extension [S1, S2, S3, A1, B1, A2, B2, A3, B3, Y] (p: PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), Y])
     @scala.annotation.targetName("andThenMsMsMstoMiMiMi")
-    def andThen(
-      w: PolyMap[(Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), Monomial.Interface[Unit, Unit => Unit, _], Y],
-      f: S1 => A1,
-      g: S2 => A2,
-      h: S3 => A3,
-    ): PolyMap[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[Unit, Unit => Unit, _], Y] =
-      new PolyMap[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[Unit, Unit => Unit, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[Unit, Unit => Unit, _], Y] =
+    def andThen[I, O](
+      w: PolyMap[(Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), Monomial.Interface[I, I => O, _], Y],
+    ): PolyMap[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[I, I => O, _], Y] =
+      new PolyMap[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[I, I => O, _], Y]:
+        def φ: PolyMap.Phi[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[I, I => O, _], Y] =
           p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[Unit, Unit => Unit, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[I, I => O, _], Y] =
           (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen.scala
@@ -26,7 +26,7 @@ object andThen:
         def φ: PolyMap.Phi[PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
           (p.φ._1.andThen(w.φ._1), p.φ._2.andThen(w.φ._2))
         def `φ#`: PolyMap.PhiSharp[PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
-          ((s, a) => p.`φ#`._1(s, a), (s, a) => p.`φ#`._2(s, a))    
+          ((s, a) => p.`φ#`._1(s, a), (s, a) => p.`φ#`._2(s, a))  
 
   extension [S1, S2, A1, B1, A2, B2, Y] (p: PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], Y])
     @scala.annotation.targetName("andThenTensoredStoreTensoredMonoToMonof")

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormSTensormS_mITensormITensormI.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormSTensormS_mITensormITensormI.scala
@@ -1,0 +1,18 @@
+package polynomial.morphism.methods.andThen
+
+import polynomial.morphism.PolyMap
+import polynomial.`object`.Monomial
+import polynomial.product.⊗
+
+object mSTensormSTensorms_mITensormITensormI:
+
+  extension [S1, S2, S3, A1, B1, A2, B2, A3, B3, Y] (p: PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), Y])
+    @scala.annotation.targetName("andThenMsMsMstoMiMiMi")
+    def andThen[I, O](
+      w: PolyMap[(Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), Monomial.Interface[I, I => O, _], Y],
+    ): PolyMap[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[I, I => O, _], Y] =
+      new PolyMap[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[I, I => O, _], Y]:
+        def φ: PolyMap.Phi[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[I, I => O, _], Y] =
+          p.φ.andThen(w.φ)
+        def `φ#`: PolyMap.PhiSharp[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[I, I => O, _], Y] =
+          (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormSTensormS_mITensormITensormI.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormSTensormS_mITensormITensormI.scala
@@ -1,18 +1,18 @@
 package polynomial.morphism.methods.andThen
 
 import polynomial.morphism.PolyMap
-import polynomial.`object`.Mono
+import polynomial.`object`.Monomial.{Interface, Store}
 import polynomial.product.⊗
 
 object mSTensormSTensorms_mITensormITensormI:
 
-  extension [S1, S2, S3, A1, B1, A2, B2, A3, B3, Y] (p: PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _] ⊗ Mono.Store[S3, _]), (Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _] ⊗ Mono.Interface[A3, B3, _]), Y])
+  extension [S1, S2, S3, A1, B1, A2, B2, A3, B3, Y] (p: PolyMap[(Store[S1, _] ⊗ Store[S2, _] ⊗ Store[S3, _]), (Interface[A1, B1, _] ⊗ Interface[A2, B2, _] ⊗ Interface[A3, B3, _]), Y])
     @scala.annotation.targetName("andThenMsMsMstoMiMiMi")
     def andThen[I, O](
-      w: PolyMap[(Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _] ⊗ Mono.Interface[A3, B3, _]), Mono.Interface[I, I => O, _], Y],
-    ): PolyMap[PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _] ⊗ Mono.Store[S3, _]), (Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _] ⊗ Mono.Interface[A3, B3, _]), _], Mono.Interface[I, I => O, _], Y] =
-      new PolyMap[PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _] ⊗ Mono.Store[S3, _]), (Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _] ⊗ Mono.Interface[A3, B3, _]), _], Mono.Interface[I, I => O, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _] ⊗ Mono.Store[S3, _]), (Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _] ⊗ Mono.Interface[A3, B3, _]), _], Mono.Interface[I, I => O, _], Y] =
+      w: PolyMap[(Interface[A1, B1, _] ⊗ Interface[A2, B2, _] ⊗ Interface[A3, B3, _]), Interface[I, I => O, _], Y],
+    ): PolyMap[PolyMap[(Store[S1, _] ⊗ Store[S2, _] ⊗ Store[S3, _]), (Interface[A1, B1, _] ⊗ Interface[A2, B2, _] ⊗ Interface[A3, B3, _]), _], Interface[I, I => O, _], Y] =
+      new PolyMap[PolyMap[(Store[S1, _] ⊗ Store[S2, _] ⊗ Store[S3, _]), (Interface[A1, B1, _] ⊗ Interface[A2, B2, _] ⊗ Interface[A3, B3, _]), _], Interface[I, I => O, _], Y]:
+        def φ: PolyMap.Phi[PolyMap[(Store[S1, _] ⊗ Store[S2, _] ⊗ Store[S3, _]), (Interface[A1, B1, _] ⊗ Interface[A2, B2, _] ⊗ Interface[A3, B3, _]), _], Interface[I, I => O, _], Y] =
           p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _] ⊗ Mono.Store[S3, _]), (Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _] ⊗ Mono.Interface[A3, B3, _]), _], Mono.Interface[I, I => O, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[(Store[S1, _] ⊗ Store[S2, _] ⊗ Store[S3, _]), (Interface[A1, B1, _] ⊗ Interface[A2, B2, _] ⊗ Interface[A3, B3, _]), _], Interface[I, I => O, _], Y] =
           (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormSTensormS_mITensormITensormI.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormSTensormS_mITensormITensormI.scala
@@ -1,18 +1,18 @@
 package polynomial.morphism.methods.andThen
 
 import polynomial.morphism.PolyMap
-import polynomial.`object`.Monomial
+import polynomial.`object`.Mono
 import polynomial.product.⊗
 
 object mSTensormSTensorms_mITensormITensormI:
 
-  extension [S1, S2, S3, A1, B1, A2, B2, A3, B3, Y] (p: PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), Y])
+  extension [S1, S2, S3, A1, B1, A2, B2, A3, B3, Y] (p: PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _] ⊗ Mono.Store[S3, _]), (Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _] ⊗ Mono.Interface[A3, B3, _]), Y])
     @scala.annotation.targetName("andThenMsMsMstoMiMiMi")
     def andThen[I, O](
-      w: PolyMap[(Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), Monomial.Interface[I, I => O, _], Y],
-    ): PolyMap[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[I, I => O, _], Y] =
-      new PolyMap[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[I, I => O, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[I, I => O, _], Y] =
+      w: PolyMap[(Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _] ⊗ Mono.Interface[A3, B3, _]), Mono.Interface[I, I => O, _], Y],
+    ): PolyMap[PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _] ⊗ Mono.Store[S3, _]), (Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _] ⊗ Mono.Interface[A3, B3, _]), _], Mono.Interface[I, I => O, _], Y] =
+      new PolyMap[PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _] ⊗ Mono.Store[S3, _]), (Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _] ⊗ Mono.Interface[A3, B3, _]), _], Mono.Interface[I, I => O, _], Y]:
+        def φ: PolyMap.Phi[PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _] ⊗ Mono.Store[S3, _]), (Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _] ⊗ Mono.Interface[A3, B3, _]), _], Mono.Interface[I, I => O, _], Y] =
           p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[I, I => O, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _] ⊗ Mono.Store[S3, _]), (Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _] ⊗ Mono.Interface[A3, B3, _]), _], Mono.Interface[I, I => O, _], Y] =
           (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormS_bITensorbI.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormS_bITensorbI.scala
@@ -1,23 +1,23 @@
 package polynomial.morphism.methods.andThen
 
 import polynomial.morphism.PolyMap
-import polynomial.`object`.{Monomial, Binomial}
+import polynomial.`object`.{Mono, Bi}
 import polynomial.product.⊗
 
 object mSTensormS_bITensorbI:
 
-  extension [S1, S2, A1, B1, A2, B2, A3, B3, A4, B4, Y] (p: PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _]), Y])
+  extension [S1, S2, A1, B1, A2, B2, A3, B3, A4, B4, Y] (p: PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]), (Bi.Interface[A1, B1, A2, B2, _] ⊗ Bi.Interface[A3, B3, A4, B4, _]), Y])
     @scala.annotation.targetName("andThenTensorStoreTensorBiToBi")
     def andThen(
-      w: PolyMap[Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _], Binomial.Interface[A1, A1 => B3, A2, A2 => B4, _], Y],
-    ): PolyMap[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _]), _], Binomial.Interface[A1, A1 => B3, A2, A2 => B4, _], Y] =
-      new PolyMap[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _]), _], Binomial.Interface[A1, A1 => B3, A2, A2 => B4, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _]), _], Binomial.Interface[A1, A1 => B3, A2, A2 => B4, _], Y] =
+      w: PolyMap[Bi.Interface[A1, B1, A2, B2, _] ⊗ Bi.Interface[A3, B3, A4, B4, _], Bi.Interface[A1, A1 => B3, A2, A2 => B4, _], Y],
+    ): PolyMap[PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]), (Bi.Interface[A1, B1, A2, B2, _] ⊗ Bi.Interface[A3, B3, A4, B4, _]), _], Bi.Interface[A1, A1 => B3, A2, A2 => B4, _], Y] =
+      new PolyMap[PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]), (Bi.Interface[A1, B1, A2, B2, _] ⊗ Bi.Interface[A3, B3, A4, B4, _]), _], Bi.Interface[A1, A1 => B3, A2, A2 => B4, _], Y]:
+        def φ: PolyMap.Phi[PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]), (Bi.Interface[A1, B1, A2, B2, _] ⊗ Bi.Interface[A3, B3, A4, B4, _]), _], Bi.Interface[A1, A1 => B3, A2, A2 => B4, _], Y] =
           (
             p.φ._1.andThen(w.φ._1),
             p.φ._2.andThen(w.φ._2),
           )
-        def `φ#`: PolyMap.PhiSharp[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _]), _], Binomial.Interface[A1, A1 => B3, A2, A2 => B4, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]), (Bi.Interface[A1, B1, A2, B2, _] ⊗ Bi.Interface[A3, B3, A4, B4, _]), _], Bi.Interface[A1, A1 => B3, A2, A2 => B4, _], Y] =
           (
             (s, a) => p.`φ#`._1(s, w.`φ#`._1(p.φ._1(s), a)),
             (s, a) => p.`φ#`._2(s, w.`φ#`._2(p.φ._2(s), a)),

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormS_bITensorbI.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormS_bITensorbI.scala
@@ -1,23 +1,24 @@
 package polynomial.morphism.methods.andThen
 
 import polynomial.morphism.PolyMap
-import polynomial.`object`.{Mono, Bi}
+import polynomial.`object`.Binomial.BiInterface
+import polynomial.`object`.Monomial.Store
 import polynomial.product.⊗
 
 object mSTensormS_bITensorbI:
 
-  extension [S1, S2, A1, B1, A2, B2, A3, B3, A4, B4, Y] (p: PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]), (Bi.Interface[A1, B1, A2, B2, _] ⊗ Bi.Interface[A3, B3, A4, B4, _]), Y])
+  extension [S1, S2, A1, B1, A2, B2, A3, B3, A4, B4, Y] (p: PolyMap[(Store[S1, _] ⊗ Store[S2, _]), (BiInterface[A1, B1, A2, B2, _] ⊗ BiInterface[A3, B3, A4, B4, _]), Y])
     @scala.annotation.targetName("andThenTensorStoreTensorBiToBi")
     def andThen(
-      w: PolyMap[Bi.Interface[A1, B1, A2, B2, _] ⊗ Bi.Interface[A3, B3, A4, B4, _], Bi.Interface[A1, A1 => B3, A2, A2 => B4, _], Y],
-    ): PolyMap[PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]), (Bi.Interface[A1, B1, A2, B2, _] ⊗ Bi.Interface[A3, B3, A4, B4, _]), _], Bi.Interface[A1, A1 => B3, A2, A2 => B4, _], Y] =
-      new PolyMap[PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]), (Bi.Interface[A1, B1, A2, B2, _] ⊗ Bi.Interface[A3, B3, A4, B4, _]), _], Bi.Interface[A1, A1 => B3, A2, A2 => B4, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]), (Bi.Interface[A1, B1, A2, B2, _] ⊗ Bi.Interface[A3, B3, A4, B4, _]), _], Bi.Interface[A1, A1 => B3, A2, A2 => B4, _], Y] =
+      w: PolyMap[BiInterface[A1, B1, A2, B2, _] ⊗ BiInterface[A3, B3, A4, B4, _], BiInterface[A1, A1 => B3, A2, A2 => B4, _], Y],
+    ): PolyMap[PolyMap[(Store[S1, _] ⊗ Store[S2, _]), (BiInterface[A1, B1, A2, B2, _] ⊗ BiInterface[A3, B3, A4, B4, _]), _], BiInterface[A1, A1 => B3, A2, A2 => B4, _], Y] =
+      new PolyMap[PolyMap[(Store[S1, _] ⊗ Store[S2, _]), (BiInterface[A1, B1, A2, B2, _] ⊗ BiInterface[A3, B3, A4, B4, _]), _], BiInterface[A1, A1 => B3, A2, A2 => B4, _], Y]:
+        def φ: PolyMap.Phi[PolyMap[(Store[S1, _] ⊗ Store[S2, _]), (BiInterface[A1, B1, A2, B2, _] ⊗ BiInterface[A3, B3, A4, B4, _]), _], BiInterface[A1, A1 => B3, A2, A2 => B4, _], Y] =
           (
             p.φ._1.andThen(w.φ._1),
             p.φ._2.andThen(w.φ._2),
           )
-        def `φ#`: PolyMap.PhiSharp[PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]), (Bi.Interface[A1, B1, A2, B2, _] ⊗ Bi.Interface[A3, B3, A4, B4, _]), _], Bi.Interface[A1, A1 => B3, A2, A2 => B4, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[(Store[S1, _] ⊗ Store[S2, _]), (BiInterface[A1, B1, A2, B2, _] ⊗ BiInterface[A3, B3, A4, B4, _]), _], BiInterface[A1, A1 => B3, A2, A2 => B4, _], Y] =
           (
             (s, a) => p.`φ#`._1(s, w.`φ#`._1(p.φ._1(s), a)),
             (s, a) => p.`φ#`._2(s, w.`φ#`._2(p.φ._2(s), a)),

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormS_bITensorbI.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormS_bITensorbI.scala
@@ -1,0 +1,24 @@
+package polynomial.morphism.methods.andThen
+
+import polynomial.morphism.PolyMap
+import polynomial.`object`.{Monomial, Binomial}
+import polynomial.product.⊗
+
+object mSTensormS_bITensorbI:
+
+  extension [S1, S2, A1, B1, A2, B2, A3, B3, A4, B4, Y] (p: PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _]), Y])
+    @scala.annotation.targetName("andThenTensorStoreTensorBiToBi")
+    def andThen(
+      w: PolyMap[Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _], Binomial.Interface[A1, A1 => B3, A2, A2 => B4, _], Y],
+    ): PolyMap[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _]), _], Binomial.Interface[A1, A1 => B3, A2, A2 => B4, _], Y] =
+      new PolyMap[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _]), _], Binomial.Interface[A1, A1 => B3, A2, A2 => B4, _], Y]:
+        def φ: PolyMap.Phi[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _]), _], Binomial.Interface[A1, A1 => B3, A2, A2 => B4, _], Y] =
+          (
+            p.φ._1.andThen(w.φ._1),
+            p.φ._2.andThen(w.φ._2),
+          )
+        def `φ#`: PolyMap.PhiSharp[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _]), _], Binomial.Interface[A1, A1 => B3, A2, A2 => B4, _], Y] =
+          (
+            (s, a) => p.`φ#`._1(s, w.`φ#`._1(p.φ._1(s), a)),
+            (s, a) => p.`φ#`._2(s, w.`φ#`._2(p.φ._2(s), a)),
+          )

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormS_mITensormI.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormS_mITensormI.scala
@@ -1,62 +1,62 @@
 package polynomial.morphism.methods.andThen
 
 import polynomial.morphism.{PolyMap, ~>}
-import polynomial.`object`.Mono
+import polynomial.`object`.Monomial.{Interface, Store}
 import polynomial.product.⊗
 
 object mSTensormS_mITensormI:
 
-  extension [S1, S2, A1, B1, A2, B2, Y] (p: PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], Y])
+  extension [S1, S2, A1, B1, A2, B2, Y] (p: PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], Y])
     @scala.annotation.targetName("andThenTensoredStoreTensoredMonoToMonof")
     def andThen(
-      w: PolyMap[Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], Mono.Interface[A1, A1 => B2, _], Y]
-    ): PolyMap[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A1, A1 => B2, _], Y] =
-      new PolyMap[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A1, A1 => B2, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A1, A1 => B2, _], Y] =
+      w: PolyMap[Interface[A1, B1, _] ⊗ Interface[A2, B2, _], Interface[A1, A1 => B2, _], Y]
+    ): PolyMap[PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], _], Interface[A1, A1 => B2, _], Y] =
+      new PolyMap[PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], _], Interface[A1, A1 => B2, _], Y]:
+        def φ: PolyMap.Phi[PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], _], Interface[A1, A1 => B2, _], Y] =
           p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A1, A1 => B2, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], _], Interface[A1, A1 => B2, _], Y] =
           (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))
 
-  extension [S1, S2, A1, B1, A2, B2, Y] (p: PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], Y])
+  extension [S1, S2, A1, B1, A2, B2, Y] (p: PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], Y])
     @scala.annotation.targetName("andThenTensoredStoreTensoredMonoToMono")
     def andThen(
-      w: PolyMap[Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], Mono.Interface[A1, B2, _], Y]
-    ): PolyMap[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A1, B2, _], Y] =
-      new PolyMap[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A1, B2, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A1, B2, _], Y] =
+      w: PolyMap[Interface[A1, B1, _] ⊗ Interface[A2, B2, _], Interface[A1, B2, _], Y]
+    ): PolyMap[PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], _], Interface[A1, B2, _], Y] =
+      new PolyMap[PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], _], Interface[A1, B2, _], Y]:
+        def φ: PolyMap.Phi[PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], _], Interface[A1, B2, _], Y] =
           p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A1, B2, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], _], Interface[A1, B2, _], Y] =
           (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))
 
-  extension [S1, S2, A, B, C, Y] (p: PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]), (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Y])
+  extension [S1, S2, A, B, C, Y] (p: PolyMap[(Store[S1, _] ⊗ Store[S2, _]), (Interface[(A, B), C, _] ⊗ Interface[C, B, _]), Y])
     @scala.annotation.targetName("andThenTensoredStoreTensoredMonoToMono2")
     def andThen(
-      w: PolyMap[(Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]),  Mono.Interface[A, C, _], Y]
-    ): PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]) ~> (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, C, _], Y] =
-      new PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]) ~> (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, C, _], Y]:
-        def φ: PolyMap.Phi[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]) ~> (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, C, _], Y] =
+      w: PolyMap[(Interface[(A, B), C, _] ⊗ Interface[C, B, _]),  Interface[A, C, _], Y]
+    ): PolyMap[(Store[S1, _] ⊗ Store[S2, _]) ~> (Interface[(A, B), C, _] ⊗ Interface[C, B, _]), Interface[A, C, _], Y] =
+      new PolyMap[(Store[S1, _] ⊗ Store[S2, _]) ~> (Interface[(A, B), C, _] ⊗ Interface[C, B, _]), Interface[A, C, _], Y]:
+        def φ: PolyMap.Phi[(Store[S1, _] ⊗ Store[S2, _]) ~> (Interface[(A, B), C, _] ⊗ Interface[C, B, _]), Interface[A, C, _], Y] =
           p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]) ~> (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, C, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[(Store[S1, _] ⊗ Store[S2, _]) ~> (Interface[(A, B), C, _] ⊗ Interface[C, B, _]), Interface[A, C, _], Y] =
           (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))
 
-  extension [S1, S2, A, B, C, Y] (p: PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]), (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Y])
+  extension [S1, S2, A, B, C, Y] (p: PolyMap[(Store[S1, _] ⊗ Store[S2, _]), (Interface[(A, B), C, _] ⊗ Interface[C, B, _]), Y])
     @scala.annotation.targetName("andThenTensoredStoreTensoredMonoToMono3")
     def andThen(
-      w: PolyMap[(Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]),  Mono.Interface[A, A => C, _], Y]
-    ): PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]) ~> (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, A => C, _], Y] =
-      new PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]) ~> (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, A => C, _], Y]:
-        def φ: PolyMap.Phi[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]) ~> (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, A => C, _], Y] =
+      w: PolyMap[(Interface[(A, B), C, _] ⊗ Interface[C, B, _]),  Interface[A, A => C, _], Y]
+    ): PolyMap[(Store[S1, _] ⊗ Store[S2, _]) ~> (Interface[(A, B), C, _] ⊗ Interface[C, B, _]), Interface[A, A => C, _], Y] =
+      new PolyMap[(Store[S1, _] ⊗ Store[S2, _]) ~> (Interface[(A, B), C, _] ⊗ Interface[C, B, _]), Interface[A, A => C, _], Y]:
+        def φ: PolyMap.Phi[(Store[S1, _] ⊗ Store[S2, _]) ~> (Interface[(A, B), C, _] ⊗ Interface[C, B, _]), Interface[A, A => C, _], Y] =
           p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]) ~> (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, A => C, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[(Store[S1, _] ⊗ Store[S2, _]) ~> (Interface[(A, B), C, _] ⊗ Interface[C, B, _]), Interface[A, A => C, _], Y] =
           (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))
 
-  extension [S1, S2, A1, B1, A2, B2, Y] (p: PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], Y])
+  extension [S1, S2, A1, B1, A2, B2, Y] (p: PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], Y])
     @scala.annotation.targetName("andThenTensoredStoreTensoredMonoToTensoredMono")
     def andThen[A3, B3, A4, B4](
-      w: PolyMap[Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], Mono.Interface[A3, B3, _] ⊗ Mono.Interface[A4, B4, _], Y]
-    ): PolyMap[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A3, B3, _] ⊗ Mono.Interface[A4, B4, _], Y] =
-      new PolyMap[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A3, B3, _] ⊗ Mono.Interface[A4, B4, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A3, B3, _] ⊗ Mono.Interface[A4, B4, _], Y] =
+      w: PolyMap[Interface[A1, B1, _] ⊗ Interface[A2, B2, _], Interface[A3, B3, _] ⊗ Interface[A4, B4, _], Y]
+    ): PolyMap[PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], _], Interface[A3, B3, _] ⊗ Interface[A4, B4, _], Y] =
+      new PolyMap[PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], _], Interface[A3, B3, _] ⊗ Interface[A4, B4, _], Y]:
+        def φ: PolyMap.Phi[PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], _], Interface[A3, B3, _] ⊗ Interface[A4, B4, _], Y] =
           p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A3, B3, _] ⊗ Mono.Interface[A4, B4, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[Store[S1, _] ⊗ Store[S2, _], Interface[A1, B1, _] ⊗ Interface[A2, B2, _], _], Interface[A3, B3, _] ⊗ Interface[A4, B4, _], Y] =
           (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormS_mITensormI.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormS_mITensormI.scala
@@ -1,32 +1,10 @@
-package polynomial.morphism.methods
+package polynomial.morphism.methods.andThen
 
 import polynomial.morphism.{PolyMap, ~>}
-import polynomial.`object`.{Binomial, Monomial}
+import polynomial.`object`.Monomial
 import polynomial.product.⊗
 
-object andThen:
-
-  extension [S, A1, B1, Y] (p: PolyMap[Monomial.Store[S, _], Monomial.Interface[A1, B1, _], Y])
-    @scala.annotation.targetName("andThenStoreMonoToMono")
-    def andThen[A2, B2](
-      w: PolyMap[Monomial.Interface[A1, B1, _], Monomial.Interface[A2, B2, _], Y]
-    ): PolyMap[PolyMap[Monomial.Store[S, _], Monomial.Interface[A1, B1, _], _], Monomial.Interface[A2, B2, _], Y] =
-      new PolyMap[PolyMap[Monomial.Store[S, _], Monomial.Interface[A1, B1, _], _], Monomial.Interface[A2, B2, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[Monomial.Store[S, _], Monomial.Interface[A1, B1, _], _], Monomial.Interface[A2, B2, _], Y] =
-          p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[PolyMap[Monomial.Store[S, _], Monomial.Interface[A1, B1, _], _], Monomial.Interface[A2, B2, _], Y] =
-          (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))
-
-  extension [S, A1, B1, A2, B2, Y] (p: PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], Y])
-    @scala.annotation.targetName("andThenStoreBiToBi")
-    def andThen(
-      w: PolyMap[Binomial.Interface[A1, B1, A2, B2, _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y]
-    ): PolyMap[PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
-      new PolyMap[PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
-          (p.φ._1.andThen(w.φ._1), p.φ._2.andThen(w.φ._2))
-        def `φ#`: PolyMap.PhiSharp[PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
-          ((s, a) => p.`φ#`._1(s, a), (s, a) => p.`φ#`._2(s, a))  
+object mSTensormS_mITensormI:
 
   extension [S1, S2, A1, B1, A2, B2, Y] (p: PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], Y])
     @scala.annotation.targetName("andThenTensoredStoreTensoredMonoToMonof")
@@ -81,32 +59,4 @@ object andThen:
         def φ: PolyMap.Phi[PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], _], Monomial.Interface[A3, B3, _] ⊗ Monomial.Interface[A4, B4, _], Y] =
           p.φ.andThen(w.φ)
         def `φ#`: PolyMap.PhiSharp[PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], _], Monomial.Interface[A3, B3, _] ⊗ Monomial.Interface[A4, B4, _], Y] =
-          (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))
-
-  extension [S1, S2, A1, B1, A2, B2, A3, B3, A4, B4, Y] (p: PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _]), Y])
-    @scala.annotation.targetName("andThenTensorStoreTensorBiToBi")
-    def andThen(
-      w: PolyMap[Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _], Binomial.Interface[A1, A1 => B3, A2, A2 => B4, _], Y],
-    ): PolyMap[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _]), _], Binomial.Interface[A1, A1 => B3, A2, A2 => B4, _], Y] =
-      new PolyMap[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _]), _], Binomial.Interface[A1, A1 => B3, A2, A2 => B4, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _]), _], Binomial.Interface[A1, A1 => B3, A2, A2 => B4, _], Y] =
-          (
-            p.φ._1.andThen(w.φ._1),
-            p.φ._2.andThen(w.φ._2),
-          )
-        def `φ#`: PolyMap.PhiSharp[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Binomial.Interface[A1, B1, A2, B2, _] ⊗ Binomial.Interface[A3, B3, A4, B4, _]), _], Binomial.Interface[A1, A1 => B3, A2, A2 => B4, _], Y] =
-          (
-            (s, a) => p.`φ#`._1(s, w.`φ#`._1(p.φ._1(s), a)),
-            (s, a) => p.`φ#`._2(s, w.`φ#`._2(p.φ._2(s), a)),
-          )
-
-  extension [S1, S2, S3, A1, B1, A2, B2, A3, B3, Y] (p: PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), Y])
-    @scala.annotation.targetName("andThenMsMsMstoMiMiMi")
-    def andThen[I, O](
-      w: PolyMap[(Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), Monomial.Interface[I, I => O, _], Y],
-    ): PolyMap[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[I, I => O, _], Y] =
-      new PolyMap[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[I, I => O, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[I, I => O, _], Y] =
-          p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _] ⊗ Monomial.Store[S3, _]), (Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _] ⊗ Monomial.Interface[A3, B3, _]), _], Monomial.Interface[I, I => O, _], Y] =
           (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormS_mITensormI.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mSTensormS_mITensormI.scala
@@ -1,62 +1,62 @@
 package polynomial.morphism.methods.andThen
 
 import polynomial.morphism.{PolyMap, ~>}
-import polynomial.`object`.Monomial
+import polynomial.`object`.Mono
 import polynomial.product.⊗
 
 object mSTensormS_mITensormI:
 
-  extension [S1, S2, A1, B1, A2, B2, Y] (p: PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], Y])
+  extension [S1, S2, A1, B1, A2, B2, Y] (p: PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], Y])
     @scala.annotation.targetName("andThenTensoredStoreTensoredMonoToMonof")
     def andThen(
-      w: PolyMap[Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], Monomial.Interface[A1, A1 => B2, _], Y]
-    ): PolyMap[PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], _], Monomial.Interface[A1, A1 => B2, _], Y] =
-      new PolyMap[PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], _], Monomial.Interface[A1, A1 => B2, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], _], Monomial.Interface[A1, A1 => B2, _], Y] =
+      w: PolyMap[Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], Mono.Interface[A1, A1 => B2, _], Y]
+    ): PolyMap[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A1, A1 => B2, _], Y] =
+      new PolyMap[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A1, A1 => B2, _], Y]:
+        def φ: PolyMap.Phi[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A1, A1 => B2, _], Y] =
           p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], _], Monomial.Interface[A1, A1 => B2, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A1, A1 => B2, _], Y] =
           (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))
 
-  extension [S1, S2, A1, B1, A2, B2, Y] (p: PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], Y])
+  extension [S1, S2, A1, B1, A2, B2, Y] (p: PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], Y])
     @scala.annotation.targetName("andThenTensoredStoreTensoredMonoToMono")
     def andThen(
-      w: PolyMap[Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], Monomial.Interface[A1, B2, _], Y]
-    ): PolyMap[PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], _], Monomial.Interface[A1, B2, _], Y] =
-      new PolyMap[PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], _], Monomial.Interface[A1, B2, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], _], Monomial.Interface[A1, B2, _], Y] =
+      w: PolyMap[Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], Mono.Interface[A1, B2, _], Y]
+    ): PolyMap[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A1, B2, _], Y] =
+      new PolyMap[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A1, B2, _], Y]:
+        def φ: PolyMap.Phi[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A1, B2, _], Y] =
           p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], _], Monomial.Interface[A1, B2, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A1, B2, _], Y] =
           (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))
 
-  extension [S1, S2, A, B, C, Y] (p: PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Monomial.Interface[(A, B), C, _] ⊗ Monomial.Interface[C, B, _]), Y])
+  extension [S1, S2, A, B, C, Y] (p: PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]), (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Y])
     @scala.annotation.targetName("andThenTensoredStoreTensoredMonoToMono2")
     def andThen(
-      w: PolyMap[(Monomial.Interface[(A, B), C, _] ⊗ Monomial.Interface[C, B, _]),  Monomial.Interface[A, C, _], Y]
-    ): PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]) ~> (Monomial.Interface[(A, B), C, _] ⊗ Monomial.Interface[C, B, _]), Monomial.Interface[A, C, _], Y] =
-      new PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]) ~> (Monomial.Interface[(A, B), C, _] ⊗ Monomial.Interface[C, B, _]), Monomial.Interface[A, C, _], Y]:
-        def φ: PolyMap.Phi[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]) ~> (Monomial.Interface[(A, B), C, _] ⊗ Monomial.Interface[C, B, _]), Monomial.Interface[A, C, _], Y] =
+      w: PolyMap[(Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]),  Mono.Interface[A, C, _], Y]
+    ): PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]) ~> (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, C, _], Y] =
+      new PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]) ~> (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, C, _], Y]:
+        def φ: PolyMap.Phi[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]) ~> (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, C, _], Y] =
           p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]) ~> (Monomial.Interface[(A, B), C, _] ⊗ Monomial.Interface[C, B, _]), Monomial.Interface[A, C, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]) ~> (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, C, _], Y] =
           (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))
 
-  extension [S1, S2, A, B, C, Y] (p: PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]), (Monomial.Interface[(A, B), C, _] ⊗ Monomial.Interface[C, B, _]), Y])
+  extension [S1, S2, A, B, C, Y] (p: PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]), (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Y])
     @scala.annotation.targetName("andThenTensoredStoreTensoredMonoToMono3")
     def andThen(
-      w: PolyMap[(Monomial.Interface[(A, B), C, _] ⊗ Monomial.Interface[C, B, _]),  Monomial.Interface[A, A => C, _], Y]
-    ): PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]) ~> (Monomial.Interface[(A, B), C, _] ⊗ Monomial.Interface[C, B, _]), Monomial.Interface[A, A => C, _], Y] =
-      new PolyMap[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]) ~> (Monomial.Interface[(A, B), C, _] ⊗ Monomial.Interface[C, B, _]), Monomial.Interface[A, A => C, _], Y]:
-        def φ: PolyMap.Phi[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]) ~> (Monomial.Interface[(A, B), C, _] ⊗ Monomial.Interface[C, B, _]), Monomial.Interface[A, A => C, _], Y] =
+      w: PolyMap[(Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]),  Mono.Interface[A, A => C, _], Y]
+    ): PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]) ~> (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, A => C, _], Y] =
+      new PolyMap[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]) ~> (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, A => C, _], Y]:
+        def φ: PolyMap.Phi[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]) ~> (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, A => C, _], Y] =
           p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[(Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _]) ~> (Monomial.Interface[(A, B), C, _] ⊗ Monomial.Interface[C, B, _]), Monomial.Interface[A, A => C, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[(Mono.Store[S1, _] ⊗ Mono.Store[S2, _]) ~> (Mono.Interface[(A, B), C, _] ⊗ Mono.Interface[C, B, _]), Mono.Interface[A, A => C, _], Y] =
           (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))
 
-  extension [S1, S2, A1, B1, A2, B2, Y] (p: PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], Y])
+  extension [S1, S2, A1, B1, A2, B2, Y] (p: PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], Y])
     @scala.annotation.targetName("andThenTensoredStoreTensoredMonoToTensoredMono")
     def andThen[A3, B3, A4, B4](
-      w: PolyMap[Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], Monomial.Interface[A3, B3, _] ⊗ Monomial.Interface[A4, B4, _], Y]
-    ): PolyMap[PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], _], Monomial.Interface[A3, B3, _] ⊗ Monomial.Interface[A4, B4, _], Y] =
-      new PolyMap[PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], _], Monomial.Interface[A3, B3, _] ⊗ Monomial.Interface[A4, B4, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], _], Monomial.Interface[A3, B3, _] ⊗ Monomial.Interface[A4, B4, _], Y] =
+      w: PolyMap[Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], Mono.Interface[A3, B3, _] ⊗ Mono.Interface[A4, B4, _], Y]
+    ): PolyMap[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A3, B3, _] ⊗ Mono.Interface[A4, B4, _], Y] =
+      new PolyMap[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A3, B3, _] ⊗ Mono.Interface[A4, B4, _], Y]:
+        def φ: PolyMap.Phi[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A3, B3, _] ⊗ Mono.Interface[A4, B4, _], Y] =
           p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[PolyMap[Monomial.Store[S1, _] ⊗ Monomial.Store[S2, _], Monomial.Interface[A1, B1, _] ⊗ Monomial.Interface[A2, B2, _], _], Monomial.Interface[A3, B3, _] ⊗ Monomial.Interface[A4, B4, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[Mono.Store[S1, _] ⊗ Mono.Store[S2, _], Mono.Interface[A1, B1, _] ⊗ Mono.Interface[A2, B2, _], _], Mono.Interface[A3, B3, _] ⊗ Mono.Interface[A4, B4, _], Y] =
           (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mS_bI.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mS_bI.scala
@@ -1,17 +1,17 @@
 package polynomial.morphism.methods.andThen
 
 import polynomial.morphism.PolyMap
-import polynomial.`object`.{Binomial, Monomial}
+import polynomial.`object`.{Bi, Mono}
 
 object mS_bI:
 
-  extension [S, A1, B1, A2, B2, Y] (p: PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], Y])
+  extension [S, A1, B1, A2, B2, Y] (p: PolyMap[Mono.Store[S, _], Bi.Interface[A1, B1, A2, B2, _], Y])
     @scala.annotation.targetName("andThenStoreBiToBi")
     def andThen(
-      w: PolyMap[Binomial.Interface[A1, B1, A2, B2, _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y]
-    ): PolyMap[PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
-      new PolyMap[PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
+      w: PolyMap[Bi.Interface[A1, B1, A2, B2, _], Bi.Interface[A1, A1 => B1, A2, A2 => B2, _], Y]
+    ): PolyMap[PolyMap[Mono.Store[S, _], Bi.Interface[A1, B1, A2, B2, _], _], Bi.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
+      new PolyMap[PolyMap[Mono.Store[S, _], Bi.Interface[A1, B1, A2, B2, _], _], Bi.Interface[A1, A1 => B1, A2, A2 => B2, _], Y]:
+        def φ: PolyMap.Phi[PolyMap[Mono.Store[S, _], Bi.Interface[A1, B1, A2, B2, _], _], Bi.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
           (p.φ._1.andThen(w.φ._1), p.φ._2.andThen(w.φ._2))
-        def `φ#`: PolyMap.PhiSharp[PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[Mono.Store[S, _], Bi.Interface[A1, B1, A2, B2, _], _], Bi.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
           ((s, a) => p.`φ#`._1(s, a), (s, a) => p.`φ#`._2(s, a))  

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mS_bI.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mS_bI.scala
@@ -1,0 +1,17 @@
+package polynomial.morphism.methods.andThen
+
+import polynomial.morphism.PolyMap
+import polynomial.`object`.{Binomial, Monomial}
+
+object mS_bI:
+
+  extension [S, A1, B1, A2, B2, Y] (p: PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], Y])
+    @scala.annotation.targetName("andThenStoreBiToBi")
+    def andThen(
+      w: PolyMap[Binomial.Interface[A1, B1, A2, B2, _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y]
+    ): PolyMap[PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
+      new PolyMap[PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y]:
+        def φ: PolyMap.Phi[PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
+          (p.φ._1.andThen(w.φ._1), p.φ._2.andThen(w.φ._2))
+        def `φ#`: PolyMap.PhiSharp[PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], _], Binomial.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
+          ((s, a) => p.`φ#`._1(s, a), (s, a) => p.`φ#`._2(s, a))  

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mS_bI.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mS_bI.scala
@@ -1,17 +1,18 @@
 package polynomial.morphism.methods.andThen
 
 import polynomial.morphism.PolyMap
-import polynomial.`object`.{Bi, Mono}
+import polynomial.`object`.Binomial.BiInterface
+import polynomial.`object`.Monomial.Store
 
 object mS_bI:
 
-  extension [S, A1, B1, A2, B2, Y] (p: PolyMap[Mono.Store[S, _], Bi.Interface[A1, B1, A2, B2, _], Y])
+  extension [S, A1, B1, A2, B2, Y] (p: PolyMap[Store[S, _], BiInterface[A1, B1, A2, B2, _], Y])
     @scala.annotation.targetName("andThenStoreBiToBi")
     def andThen(
-      w: PolyMap[Bi.Interface[A1, B1, A2, B2, _], Bi.Interface[A1, A1 => B1, A2, A2 => B2, _], Y]
-    ): PolyMap[PolyMap[Mono.Store[S, _], Bi.Interface[A1, B1, A2, B2, _], _], Bi.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
-      new PolyMap[PolyMap[Mono.Store[S, _], Bi.Interface[A1, B1, A2, B2, _], _], Bi.Interface[A1, A1 => B1, A2, A2 => B2, _], Y]:
-        def φ: PolyMap.Phi[PolyMap[Mono.Store[S, _], Bi.Interface[A1, B1, A2, B2, _], _], Bi.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
+      w: PolyMap[BiInterface[A1, B1, A2, B2, _], BiInterface[A1, A1 => B1, A2, A2 => B2, _], Y]
+    ): PolyMap[PolyMap[Store[S, _], BiInterface[A1, B1, A2, B2, _], _], BiInterface[A1, A1 => B1, A2, A2 => B2, _], Y] =
+      new PolyMap[PolyMap[Store[S, _], BiInterface[A1, B1, A2, B2, _], _], BiInterface[A1, A1 => B1, A2, A2 => B2, _], Y]:
+        def φ: PolyMap.Phi[PolyMap[Store[S, _], BiInterface[A1, B1, A2, B2, _], _], BiInterface[A1, A1 => B1, A2, A2 => B2, _], Y] =
           (p.φ._1.andThen(w.φ._1), p.φ._2.andThen(w.φ._2))
-        def `φ#`: PolyMap.PhiSharp[PolyMap[Mono.Store[S, _], Bi.Interface[A1, B1, A2, B2, _], _], Bi.Interface[A1, A1 => B1, A2, A2 => B2, _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[Store[S, _], BiInterface[A1, B1, A2, B2, _], _], BiInterface[A1, A1 => B1, A2, A2 => B2, _], Y] =
           ((s, a) => p.`φ#`._1(s, a), (s, a) => p.`φ#`._2(s, a))  

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mS_mI.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mS_mI.scala
@@ -2,28 +2,28 @@ package polynomial.morphism.methods.andThen
 
 import cats.Id
 import polynomial.morphism.PolyMap
-import polynomial.`object`.Mono
+import polynomial.`object`.Monomial.{Interface, Store}
 
 object mS_mI:
 
-  extension [S, A1, B1, Y] (p: PolyMap[Mono.Store[Id[S], _], Mono.Interface[Id[A1], Id[B1], _], Y])
+  extension [S, A1, B1, Y] (p: PolyMap[Store[Id[S], _], Interface[Id[A1], Id[B1], _], Y])
     @scala.annotation.targetName("andThenStoreMonoToMono")
     def andThen[A2, B2](
-      w: PolyMap[Mono.Interface[Id[A1], Id[B1], _], Mono.Interface[Id[A2], Id[B2], _], Y]
-    ): PolyMap[PolyMap[Mono.Store[Id[S], _], Mono.Interface[Id[A1], Id[B1], _], _], Mono.Interface[Id[A2], Id[B2], _], Y] =
-      new PolyMap[PolyMap[Mono.Store[Id[S], _], Mono.Interface[Id[A1], Id[B1], _], _], Mono.Interface[Id[A2], Id[B2], _], Y]:
-        def φ: PolyMap.Phi[PolyMap[Mono.Store[Id[S], _], Mono.Interface[Id[A1], Id[B1], _], _], Mono.Interface[Id[A2], Id[B2], _], Y] =
+      w: PolyMap[Interface[Id[A1], Id[B1], _], Interface[Id[A2], Id[B2], _], Y]
+    ): PolyMap[PolyMap[Store[Id[S], _], Interface[Id[A1], Id[B1], _], _], Interface[Id[A2], Id[B2], _], Y] =
+      new PolyMap[PolyMap[Store[Id[S], _], Interface[Id[A1], Id[B1], _], _], Interface[Id[A2], Id[B2], _], Y]:
+        def φ: PolyMap.Phi[PolyMap[Store[Id[S], _], Interface[Id[A1], Id[B1], _], _], Interface[Id[A2], Id[B2], _], Y] =
           p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[PolyMap[Mono.Store[Id[S], _], Mono.Interface[Id[A1], Id[B1], _], _], Mono.Interface[Id[A2], Id[B2], _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[Store[Id[S], _], Interface[Id[A1], Id[B1], _], _], Interface[Id[A2], Id[B2], _], Y] =
           (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))
 
-  extension [S, A1, B1, Y] (p: PolyMap[Mono.Store[Option[S], _], Mono.Interface[A1, Option[B1], _], Y])
+  extension [S, A1, B1, Y] (p: PolyMap[Store[Option[S], _], Interface[A1, Option[B1], _], Y])
     @scala.annotation.targetName("andThenStoreMonoToMonoOptionPrism")
     def andThen(
-      w: PolyMap[Mono.Interface[A1, Id[B1], _], Mono.Interface[A1, A1 => Option[B1], _], Y]
-    ): PolyMap[PolyMap[Mono.Store[Option[S], _], Mono.Interface[A1, Id[B1], _], _], Mono.Interface[A1, A1 => Option[B1], _], Y] =
-      new PolyMap[PolyMap[Mono.Store[Option[S], _], Mono.Interface[A1, Id[B1], _], _], Mono.Interface[A1, A1 => Option[B1], _], Y]:
-        def φ: PolyMap.Phi[PolyMap[Mono.Store[Option[S], _], Mono.Interface[A1, Id[B1], _], _], Mono.Interface[A1, A1 => Option[B1], _], Y] =
+      w: PolyMap[Interface[A1, Id[B1], _], Interface[A1, A1 => Option[B1], _], Y]
+    ): PolyMap[PolyMap[Store[Option[S], _], Interface[A1, Id[B1], _], _], Interface[A1, A1 => Option[B1], _], Y] =
+      new PolyMap[PolyMap[Store[Option[S], _], Interface[A1, Id[B1], _], _], Interface[A1, A1 => Option[B1], _], Y]:
+        def φ: PolyMap.Phi[PolyMap[Store[Option[S], _], Interface[A1, Id[B1], _], _], Interface[A1, A1 => Option[B1], _], Y] =
           s => a2 => p.φ(s).flatMap(b1 => w.φ(b1)(a2))
-        def `φ#`: PolyMap.PhiSharp[PolyMap[Mono.Store[Option[S], _], Mono.Interface[A1, Id[B1], _], _], Mono.Interface[A1, A1 => Option[B1], _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[Store[Option[S], _], Interface[A1, Id[B1], _], _], Interface[A1, A1 => Option[B1], _], Y] =
           (s, a) => p.φ(s).flatMap(b1 => p.`φ#`(s, w.`φ#`(b1, a)))

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mS_mI.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mS_mI.scala
@@ -1,0 +1,29 @@
+package polynomial.morphism.methods.andThen
+
+import cats.Id
+import polynomial.morphism.PolyMap
+import polynomial.`object`.Monomial
+
+object mS_mI:
+
+  extension [S, A1, B1, Y] (p: PolyMap[Monomial.Store[Id[S], _], Monomial.Interface[Id[A1], Id[B1], _], Y])
+    @scala.annotation.targetName("andThenStoreMonoToMono")
+    def andThen[A2, B2](
+      w: PolyMap[Monomial.Interface[Id[A1], Id[B1], _], Monomial.Interface[Id[A2], Id[B2], _], Y]
+    ): PolyMap[PolyMap[Monomial.Store[Id[S], _], Monomial.Interface[Id[A1], Id[B1], _], _], Monomial.Interface[Id[A2], Id[B2], _], Y] =
+      new PolyMap[PolyMap[Monomial.Store[Id[S], _], Monomial.Interface[Id[A1], Id[B1], _], _], Monomial.Interface[Id[A2], Id[B2], _], Y]:
+        def φ: PolyMap.Phi[PolyMap[Monomial.Store[Id[S], _], Monomial.Interface[Id[A1], Id[B1], _], _], Monomial.Interface[Id[A2], Id[B2], _], Y] =
+          p.φ.andThen(w.φ)
+        def `φ#`: PolyMap.PhiSharp[PolyMap[Monomial.Store[Id[S], _], Monomial.Interface[Id[A1], Id[B1], _], _], Monomial.Interface[Id[A2], Id[B2], _], Y] =
+          (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))
+
+  extension [S, A1, B1, Y] (p: PolyMap[Monomial.Store[Option[S], _], Monomial.Interface[A1, Option[B1], _], Y])
+    @scala.annotation.targetName("andThenStoreMonoToMonoOptionPrism")
+    def andThen(
+      w: PolyMap[Monomial.Interface[A1, Id[B1], _], Monomial.Interface[A1, A1 => Option[B1], _], Y]
+    ): PolyMap[PolyMap[Monomial.Store[Option[S], _], Monomial.Interface[A1, Id[B1], _], _], Monomial.Interface[A1, A1 => Option[B1], _], Y] =
+      new PolyMap[PolyMap[Monomial.Store[Option[S], _], Monomial.Interface[A1, Id[B1], _], _], Monomial.Interface[A1, A1 => Option[B1], _], Y]:
+        def φ: PolyMap.Phi[PolyMap[Monomial.Store[Option[S], _], Monomial.Interface[A1, Id[B1], _], _], Monomial.Interface[A1, A1 => Option[B1], _], Y] =
+          s => a2 => p.φ(s).flatMap(b1 => w.φ(b1)(a2))
+        def `φ#`: PolyMap.PhiSharp[PolyMap[Monomial.Store[Option[S], _], Monomial.Interface[A1, Id[B1], _], _], Monomial.Interface[A1, A1 => Option[B1], _], Y] =
+          (s, a) => p.φ(s).flatMap(b1 => p.`φ#`(s, w.`φ#`(b1, a)))

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mS_mI.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/andThen/mS_mI.scala
@@ -2,28 +2,28 @@ package polynomial.morphism.methods.andThen
 
 import cats.Id
 import polynomial.morphism.PolyMap
-import polynomial.`object`.Monomial
+import polynomial.`object`.Mono
 
 object mS_mI:
 
-  extension [S, A1, B1, Y] (p: PolyMap[Monomial.Store[Id[S], _], Monomial.Interface[Id[A1], Id[B1], _], Y])
+  extension [S, A1, B1, Y] (p: PolyMap[Mono.Store[Id[S], _], Mono.Interface[Id[A1], Id[B1], _], Y])
     @scala.annotation.targetName("andThenStoreMonoToMono")
     def andThen[A2, B2](
-      w: PolyMap[Monomial.Interface[Id[A1], Id[B1], _], Monomial.Interface[Id[A2], Id[B2], _], Y]
-    ): PolyMap[PolyMap[Monomial.Store[Id[S], _], Monomial.Interface[Id[A1], Id[B1], _], _], Monomial.Interface[Id[A2], Id[B2], _], Y] =
-      new PolyMap[PolyMap[Monomial.Store[Id[S], _], Monomial.Interface[Id[A1], Id[B1], _], _], Monomial.Interface[Id[A2], Id[B2], _], Y]:
-        def φ: PolyMap.Phi[PolyMap[Monomial.Store[Id[S], _], Monomial.Interface[Id[A1], Id[B1], _], _], Monomial.Interface[Id[A2], Id[B2], _], Y] =
+      w: PolyMap[Mono.Interface[Id[A1], Id[B1], _], Mono.Interface[Id[A2], Id[B2], _], Y]
+    ): PolyMap[PolyMap[Mono.Store[Id[S], _], Mono.Interface[Id[A1], Id[B1], _], _], Mono.Interface[Id[A2], Id[B2], _], Y] =
+      new PolyMap[PolyMap[Mono.Store[Id[S], _], Mono.Interface[Id[A1], Id[B1], _], _], Mono.Interface[Id[A2], Id[B2], _], Y]:
+        def φ: PolyMap.Phi[PolyMap[Mono.Store[Id[S], _], Mono.Interface[Id[A1], Id[B1], _], _], Mono.Interface[Id[A2], Id[B2], _], Y] =
           p.φ.andThen(w.φ)
-        def `φ#`: PolyMap.PhiSharp[PolyMap[Monomial.Store[Id[S], _], Monomial.Interface[Id[A1], Id[B1], _], _], Monomial.Interface[Id[A2], Id[B2], _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[Mono.Store[Id[S], _], Mono.Interface[Id[A1], Id[B1], _], _], Mono.Interface[Id[A2], Id[B2], _], Y] =
           (s, a) => p.`φ#`(s, w.`φ#`(p.φ(s), a))
 
-  extension [S, A1, B1, Y] (p: PolyMap[Monomial.Store[Option[S], _], Monomial.Interface[A1, Option[B1], _], Y])
+  extension [S, A1, B1, Y] (p: PolyMap[Mono.Store[Option[S], _], Mono.Interface[A1, Option[B1], _], Y])
     @scala.annotation.targetName("andThenStoreMonoToMonoOptionPrism")
     def andThen(
-      w: PolyMap[Monomial.Interface[A1, Id[B1], _], Monomial.Interface[A1, A1 => Option[B1], _], Y]
-    ): PolyMap[PolyMap[Monomial.Store[Option[S], _], Monomial.Interface[A1, Id[B1], _], _], Monomial.Interface[A1, A1 => Option[B1], _], Y] =
-      new PolyMap[PolyMap[Monomial.Store[Option[S], _], Monomial.Interface[A1, Id[B1], _], _], Monomial.Interface[A1, A1 => Option[B1], _], Y]:
-        def φ: PolyMap.Phi[PolyMap[Monomial.Store[Option[S], _], Monomial.Interface[A1, Id[B1], _], _], Monomial.Interface[A1, A1 => Option[B1], _], Y] =
+      w: PolyMap[Mono.Interface[A1, Id[B1], _], Mono.Interface[A1, A1 => Option[B1], _], Y]
+    ): PolyMap[PolyMap[Mono.Store[Option[S], _], Mono.Interface[A1, Id[B1], _], _], Mono.Interface[A1, A1 => Option[B1], _], Y] =
+      new PolyMap[PolyMap[Mono.Store[Option[S], _], Mono.Interface[A1, Id[B1], _], _], Mono.Interface[A1, A1 => Option[B1], _], Y]:
+        def φ: PolyMap.Phi[PolyMap[Mono.Store[Option[S], _], Mono.Interface[A1, Id[B1], _], _], Mono.Interface[A1, A1 => Option[B1], _], Y] =
           s => a2 => p.φ(s).flatMap(b1 => w.φ(b1)(a2))
-        def `φ#`: PolyMap.PhiSharp[PolyMap[Monomial.Store[Option[S], _], Monomial.Interface[A1, Id[B1], _], _], Monomial.Interface[A1, A1 => Option[B1], _], Y] =
+        def `φ#`: PolyMap.PhiSharp[PolyMap[Mono.Store[Option[S], _], Mono.Interface[A1, Id[B1], _], _], Mono.Interface[A1, A1 => Option[B1], _], Y] =
           (s, a) => p.φ(s).flatMap(b1 => p.`φ#`(s, w.`φ#`(b1, a)))

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/swap.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/swap.scala
@@ -1,29 +1,29 @@
 package polynomial.morphism.methods
 
 import polynomial.morphism.PolyMap
-import polynomial.`object`.{Bi, Mono}
-
+import polynomial.`object`.Binomial.BiInterface
+import polynomial.`object`.Monomial.Store
 object swap:
 
-  extension [S, A1, B1, A2, B2, Y] (p: PolyMap[Mono.Store[S, _], Bi.Interface[A1, B1, A2, B2, _], Y])
+  extension [S, A1, B1, A2, B2, Y] (p: PolyMap[Store[S, _], BiInterface[A1, B1, A2, B2, _], Y])
 
-    def swapInterfaceDir: PolyMap[Mono.Store[S, _], Bi.Interface[A1, B2, A2, B1, _], Y] =
-      new PolyMap[Mono.Store[S, _], Bi.Interface[A1, B2, A2, B1, _], Y]:
-        def φ: PolyMap.Phi[(Mono.Store[S, _]), (Bi.Interface[A1, B2, A2, B1, _]), Y] =
+    def swapInterfaceDir: PolyMap[Store[S, _], BiInterface[A1, B2, A2, B1, _], Y] =
+      new PolyMap[Store[S, _], BiInterface[A1, B2, A2, B1, _], Y]:
+        def φ: PolyMap.Phi[(Store[S, _]), (BiInterface[A1, B2, A2, B1, _]), Y] =
           p.φ.swap
-        def `φ#`: PolyMap.PhiSharp[(Mono.Store[S, _]), (Bi.Interface[A1, B2, A2, B1, _]), Y] =
+        def `φ#`: PolyMap.PhiSharp[(Store[S, _]), (BiInterface[A1, B2, A2, B1, _]), Y] =
           p.`φ#`
 
-    def swapInterfacePos: PolyMap[Mono.Store[S, _], Bi.Interface[A2, B1, A1, B2, _], Y] =
-      new PolyMap[Mono.Store[S, _], Bi.Interface[A2, B1, A1, B2, _], Y]:
-        def φ: PolyMap.Phi[(Mono.Store[S, _]), (Bi.Interface[A2, B1, A1, B2, _]), Y] =
+    def swapInterfacePos: PolyMap[Store[S, _], BiInterface[A2, B1, A1, B2, _], Y] =
+      new PolyMap[Store[S, _], BiInterface[A2, B1, A1, B2, _], Y]:
+        def φ: PolyMap.Phi[(Store[S, _]), (BiInterface[A2, B1, A1, B2, _]), Y] =
           p.φ
-        def `φ#`: PolyMap.PhiSharp[(Mono.Store[S, _]), (Bi.Interface[A2, B1, A1, B2, _]), Y] =
+        def `φ#`: PolyMap.PhiSharp[(Store[S, _]), (BiInterface[A2, B1, A1, B2, _]), Y] =
           p.`φ#`.swap
 
-    def swapModes: PolyMap[Mono.Store[S, _], Bi.Interface[A2, B2, A1, B1, _], Y] =
-      new PolyMap[Mono.Store[S, _], Bi.Interface[A2, B2, A1, B1, _], Y]:
-        def φ: PolyMap.Phi[(Mono.Store[S, _]), (Bi.Interface[A2, B2, A1, B1, _]), Y] =
+    def swapModes: PolyMap[Store[S, _], BiInterface[A2, B2, A1, B1, _], Y] =
+      new PolyMap[Store[S, _], BiInterface[A2, B2, A1, B1, _], Y]:
+        def φ: PolyMap.Phi[(Store[S, _]), (BiInterface[A2, B2, A1, B1, _]), Y] =
           p.φ.swap
-        def `φ#`: PolyMap.PhiSharp[(Mono.Store[S, _]), (Bi.Interface[A2, B2, A1, B1, _]), Y] =
+        def `φ#`: PolyMap.PhiSharp[(Store[S, _]), (BiInterface[A2, B2, A1, B1, _]), Y] =
           p.`φ#`.swap

--- a/modules/poly/shared/src/main/scala/polynomial/morphism/methods/swap.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/morphism/methods/swap.scala
@@ -1,29 +1,29 @@
 package polynomial.morphism.methods
 
 import polynomial.morphism.PolyMap
-import polynomial.`object`.{Binomial, Monomial}
+import polynomial.`object`.{Bi, Mono}
 
 object swap:
 
-  extension [S, A1, B1, A2, B2, Y] (p: PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B1, A2, B2, _], Y])
+  extension [S, A1, B1, A2, B2, Y] (p: PolyMap[Mono.Store[S, _], Bi.Interface[A1, B1, A2, B2, _], Y])
 
-    def swapInterfaceDir: PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B2, A2, B1, _], Y] =
-      new PolyMap[Monomial.Store[S, _], Binomial.Interface[A1, B2, A2, B1, _], Y]:
-        def φ: PolyMap.Phi[(Monomial.Store[S, _]), (Binomial.Interface[A1, B2, A2, B1, _]), Y] =
+    def swapInterfaceDir: PolyMap[Mono.Store[S, _], Bi.Interface[A1, B2, A2, B1, _], Y] =
+      new PolyMap[Mono.Store[S, _], Bi.Interface[A1, B2, A2, B1, _], Y]:
+        def φ: PolyMap.Phi[(Mono.Store[S, _]), (Bi.Interface[A1, B2, A2, B1, _]), Y] =
           p.φ.swap
-        def `φ#`: PolyMap.PhiSharp[(Monomial.Store[S, _]), (Binomial.Interface[A1, B2, A2, B1, _]), Y] =
+        def `φ#`: PolyMap.PhiSharp[(Mono.Store[S, _]), (Bi.Interface[A1, B2, A2, B1, _]), Y] =
           p.`φ#`
 
-    def swapInterfacePos: PolyMap[Monomial.Store[S, _], Binomial.Interface[A2, B1, A1, B2, _], Y] =
-      new PolyMap[Monomial.Store[S, _], Binomial.Interface[A2, B1, A1, B2, _], Y]:
-        def φ: PolyMap.Phi[(Monomial.Store[S, _]), (Binomial.Interface[A2, B1, A1, B2, _]), Y] =
+    def swapInterfacePos: PolyMap[Mono.Store[S, _], Bi.Interface[A2, B1, A1, B2, _], Y] =
+      new PolyMap[Mono.Store[S, _], Bi.Interface[A2, B1, A1, B2, _], Y]:
+        def φ: PolyMap.Phi[(Mono.Store[S, _]), (Bi.Interface[A2, B1, A1, B2, _]), Y] =
           p.φ
-        def `φ#`: PolyMap.PhiSharp[(Monomial.Store[S, _]), (Binomial.Interface[A2, B1, A1, B2, _]), Y] =
+        def `φ#`: PolyMap.PhiSharp[(Mono.Store[S, _]), (Bi.Interface[A2, B1, A1, B2, _]), Y] =
           p.`φ#`.swap
 
-    def swapModes: PolyMap[Monomial.Store[S, _], Binomial.Interface[A2, B2, A1, B1, _], Y] =
-      new PolyMap[Monomial.Store[S, _], Binomial.Interface[A2, B2, A1, B1, _], Y]:
-        def φ: PolyMap.Phi[(Monomial.Store[S, _]), (Binomial.Interface[A2, B2, A1, B1, _]), Y] =
+    def swapModes: PolyMap[Mono.Store[S, _], Bi.Interface[A2, B2, A1, B1, _], Y] =
+      new PolyMap[Mono.Store[S, _], Bi.Interface[A2, B2, A1, B1, _], Y]:
+        def φ: PolyMap.Phi[(Mono.Store[S, _]), (Bi.Interface[A2, B2, A1, B1, _]), Y] =
           p.φ.swap
-        def `φ#`: PolyMap.PhiSharp[(Monomial.Store[S, _]), (Binomial.Interface[A2, B2, A1, B1, _]), Y] =
+        def `φ#`: PolyMap.PhiSharp[(Mono.Store[S, _]), (Bi.Interface[A2, B2, A1, B1, _]), Y] =
           p.`φ#`.swap

--- a/modules/poly/shared/src/main/scala/polynomial/object.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/object.scala
@@ -25,9 +25,9 @@ object `object`:
   object Tri:
     sealed trait Interface[+A1, +B1, +A2, +B2, +A3, +B3, Y] extends Tri[A1, B1, A2, B2, A3, B3, Y]
     object Interface:
-      case class Term1[A1, B1, Y](yᵉˣᵖ: A1 => Y, coeff: B1) extends Tri[A1, B1, Nothing, Nothing, Nothing, Nothing, Y]
-      case class Term2[A2, B2, Y](yᵉˣᵖ: A2 => Y, coeff: B2) extends Tri[Nothing, Nothing, A2, B2, Nothing, Nothing, Y]
-      case class Term3[A3, B3, Y](yᵉˣᵖ: A3 => Y, coeff: B3) extends Tri[Nothing, Nothing, Nothing, Nothing, A3, B3, Y]
+      case class Term1[A1, B1, Y](yᵉˣᵖ: A1 => Y, coeff: B1) extends Tri.Interface[A1, B1, Nothing, Nothing, Nothing, Nothing, Y]
+      case class Term2[A2, B2, Y](yᵉˣᵖ: A2 => Y, coeff: B2) extends Tri.Interface[Nothing, Nothing, A2, B2, Nothing, Nothing, Y]
+      case class Term3[A3, B3, Y](yᵉˣᵖ: A3 => Y, coeff: B3) extends Tri.Interface[Nothing, Nothing, Nothing, Nothing, A3, B3, Y]
     sealed trait Store[+S1, +S2, +S3, Y] extends Tri[S1, S1, S2, S2, S3, S3, Y]
     object Store:
       case class Term1[S1, Y](yᵉˣᵖ: S1 => Y, coeff: S1) extends Store[S1, Nothing, Nothing, Y]

--- a/modules/poly/shared/src/main/scala/polynomial/object.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/object.scala
@@ -3,32 +3,32 @@ package polynomial
 object `object`:
 
   // Byᴬ
-  sealed trait Monomial[A, B, Y]
-  object Monomial:
-    case class Interface[A, B, Y](yᵉˣᵖ: A => Y, coeff: B) extends Monomial[A, B, Y]
-    case class Store[S, Y](yᵉˣᵖ: S => Y, coeff: S) extends Monomial[S, S, Y]
+  sealed trait Mono[A, B, Y]
+  object Mono:
+    case class Interface[A, B, Y](yᵉˣᵖ: A => Y, coeff: B) extends Mono[A, B, Y]
+    case class Store[S, Y](yᵉˣᵖ: S => Y, coeff: S) extends Mono[S, S, Y]
 
   // B₁yᴬ¹ + B₂yᴬ²
-  sealed trait Binomial[+A1, +B1, +A2, +B2, Y]
-  object Binomial:
-    sealed trait Interface[+A1, +B1, +A2, +B2, Y] extends Binomial[A1, B1, A2, B2, Y]
+  sealed trait Bi[+A1, +B1, +A2, +B2, Y]
+  object Bi:
+    sealed trait Interface[+A1, +B1, +A2, +B2, Y] extends Bi[A1, B1, A2, B2, Y]
     object Interface:
-      case class Term1[A1, B1, Y](yᵉˣᵖ: A1 => Y, coeff: B1) extends Binomial.Interface[A1, B1, Nothing, Nothing, Y]
-      case class Term2[A2, B2, Y](yᵉˣᵖ: A2 => Y, coeff: B2) extends Binomial.Interface[Nothing, Nothing, A2, B2, Y]
-    sealed trait Store[+S1, +S2, Y] extends Binomial[S1, S1, S2, S2, Y]
+      case class Term1[A1, B1, Y](yᵉˣᵖ: A1 => Y, coeff: B1) extends Bi.Interface[A1, B1, Nothing, Nothing, Y]
+      case class Term2[A2, B2, Y](yᵉˣᵖ: A2 => Y, coeff: B2) extends Bi.Interface[Nothing, Nothing, A2, B2, Y]
+    sealed trait Store[+S1, +S2, Y] extends Bi[S1, S1, S2, S2, Y]
     object Store:
-      case class Term1[S1, Y](yᵉˣᵖ: S1 => Y, coeff: S1) extends Binomial.Store[S1, Nothing, Y]
-      case class Term2[S2, Y](yᵉˣᵖ: S2 => Y, coeff: S2) extends Binomial.Store[Nothing, S2, Y]
+      case class Term1[S1, Y](yᵉˣᵖ: S1 => Y, coeff: S1) extends Bi.Store[S1, Nothing, Y]
+      case class Term2[S2, Y](yᵉˣᵖ: S2 => Y, coeff: S2) extends Bi.Store[Nothing, S2, Y]
 
   // B₁yᴬ¹ + B₂yᴬ² + B₃yᴬ³
-  sealed trait Trinomial[+A1, +B1, +A2, +B2, +A3, +B3, Y]
-  object Trinomial:
-    sealed trait Interface[+A1, +B1, +A2, +B2, +A3, +B3, Y] extends Trinomial[A1, B1, A2, B2, A3, B3, Y]
+  sealed trait Tri[+A1, +B1, +A2, +B2, +A3, +B3, Y]
+  object Tri:
+    sealed trait Interface[+A1, +B1, +A2, +B2, +A3, +B3, Y] extends Tri[A1, B1, A2, B2, A3, B3, Y]
     object Interface:
-      case class Term1[A1, B1, Y](yᵉˣᵖ: A1 => Y, coeff: B1) extends Trinomial[A1, B1, Nothing, Nothing, Nothing, Nothing, Y]
-      case class Term2[A2, B2, Y](yᵉˣᵖ: A2 => Y, coeff: B2) extends Trinomial[Nothing, Nothing, A2, B2, Nothing, Nothing, Y]
-      case class Term3[A3, B3, Y](yᵉˣᵖ: A3 => Y, coeff: B3) extends Trinomial[Nothing, Nothing, Nothing, Nothing, A3, B3, Y]
-    sealed trait Store[+S1, +S2, +S3, Y] extends Trinomial[S1, S1, S2, S2, S3, S3, Y]
+      case class Term1[A1, B1, Y](yᵉˣᵖ: A1 => Y, coeff: B1) extends Tri[A1, B1, Nothing, Nothing, Nothing, Nothing, Y]
+      case class Term2[A2, B2, Y](yᵉˣᵖ: A2 => Y, coeff: B2) extends Tri[Nothing, Nothing, A2, B2, Nothing, Nothing, Y]
+      case class Term3[A3, B3, Y](yᵉˣᵖ: A3 => Y, coeff: B3) extends Tri[Nothing, Nothing, Nothing, Nothing, A3, B3, Y]
+    sealed trait Store[+S1, +S2, +S3, Y] extends Tri[S1, S1, S2, S2, S3, S3, Y]
     object Store:
       case class Term1[S1, Y](yᵉˣᵖ: S1 => Y, coeff: S1) extends Store[S1, Nothing, Nothing, Y]
       case class Term2[S2, Y](yᵉˣᵖ: S2 => Y, coeff: S2) extends Store[Nothing, S2, Nothing, Y]

--- a/modules/poly/shared/src/main/scala/polynomial/object.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/object.scala
@@ -3,33 +3,33 @@ package polynomial
 object `object`:
 
   // Byᴬ
-  sealed trait Mono[A, B, Y]
-  object Mono:
-    case class Interface[A, B, Y](yᵉˣᵖ: A => Y, coeff: B) extends Mono[A, B, Y]
-    case class Store[S, Y](yᵉˣᵖ: S => Y, coeff: S) extends Mono[S, S, Y]
+  sealed trait Monomial[A, B, Y]
+  object Monomial:
+    case class Interface[A, B, Y](yᵉˣᵖ: A => Y, coeff: B) extends Monomial[A, B, Y]
+    case class Store[S, Y](yᵉˣᵖ: S => Y, coeff: S) extends Monomial[S, S, Y]
 
   // B₁yᴬ¹ + B₂yᴬ²
-  sealed trait Bi[+A1, +B1, +A2, +B2, Y]
-  object Bi:
-    sealed trait Interface[+A1, +B1, +A2, +B2, Y] extends Bi[A1, B1, A2, B2, Y]
-    object Interface:
-      case class Term1[A1, B1, Y](yᵉˣᵖ: A1 => Y, coeff: B1) extends Bi.Interface[A1, B1, Nothing, Nothing, Y]
-      case class Term2[A2, B2, Y](yᵉˣᵖ: A2 => Y, coeff: B2) extends Bi.Interface[Nothing, Nothing, A2, B2, Y]
-    sealed trait Store[+S1, +S2, Y] extends Bi[S1, S1, S2, S2, Y]
-    object Store:
-      case class Term1[S1, Y](yᵉˣᵖ: S1 => Y, coeff: S1) extends Bi.Store[S1, Nothing, Y]
-      case class Term2[S2, Y](yᵉˣᵖ: S2 => Y, coeff: S2) extends Bi.Store[Nothing, S2, Y]
+  sealed trait Binomial[+A1, +B1, +A2, +B2, Y]
+  object Binomial:
+    sealed trait BiInterface[+A1, +B1, +A2, +B2, Y] extends Binomial[A1, B1, A2, B2, Y]
+    object BiInterface:
+      case class Term1[A1, B1, Y](yᵉˣᵖ: A1 => Y, coeff: B1) extends BiInterface[A1, B1, Nothing, Nothing, Y]
+      case class Term2[A2, B2, Y](yᵉˣᵖ: A2 => Y, coeff: B2) extends BiInterface[Nothing, Nothing, A2, B2, Y]
+    sealed trait BiStore[+S1, +S2, Y] extends Binomial[S1, S1, S2, S2, Y]
+    object BiStore:
+      case class Term1[S1, Y](yᵉˣᵖ: S1 => Y, coeff: S1) extends BiStore[S1, Nothing, Y]
+      case class Term2[S2, Y](yᵉˣᵖ: S2 => Y, coeff: S2) extends BiStore[Nothing, S2, Y]
 
   // B₁yᴬ¹ + B₂yᴬ² + B₃yᴬ³
-  sealed trait Tri[+A1, +B1, +A2, +B2, +A3, +B3, Y]
-  object Tri:
-    sealed trait Interface[+A1, +B1, +A2, +B2, +A3, +B3, Y] extends Tri[A1, B1, A2, B2, A3, B3, Y]
-    object Interface:
-      case class Term1[A1, B1, Y](yᵉˣᵖ: A1 => Y, coeff: B1) extends Tri.Interface[A1, B1, Nothing, Nothing, Nothing, Nothing, Y]
-      case class Term2[A2, B2, Y](yᵉˣᵖ: A2 => Y, coeff: B2) extends Tri.Interface[Nothing, Nothing, A2, B2, Nothing, Nothing, Y]
-      case class Term3[A3, B3, Y](yᵉˣᵖ: A3 => Y, coeff: B3) extends Tri.Interface[Nothing, Nothing, Nothing, Nothing, A3, B3, Y]
-    sealed trait Store[+S1, +S2, +S3, Y] extends Tri[S1, S1, S2, S2, S3, S3, Y]
-    object Store:
-      case class Term1[S1, Y](yᵉˣᵖ: S1 => Y, coeff: S1) extends Store[S1, Nothing, Nothing, Y]
-      case class Term2[S2, Y](yᵉˣᵖ: S2 => Y, coeff: S2) extends Store[Nothing, S2, Nothing, Y]
-      case class Term3[S3, Y](yᵉˣᵖ: S3 => Y, coeff: S3) extends Store[Nothing, Nothing, S3, Y]
+  sealed trait Trinomial[+A1, +B1, +A2, +B2, +A3, +B3, Y]
+  object Trinomial:
+    sealed trait TriInterface[+A1, +B1, +A2, +B2, +A3, +B3, Y] extends Trinomial[A1, B1, A2, B2, A3, B3, Y]
+    object TriInterface:
+      case class Term1[A1, B1, Y](yᵉˣᵖ: A1 => Y, coeff: B1) extends TriInterface[A1, B1, Nothing, Nothing, Nothing, Nothing, Y]
+      case class Term2[A2, B2, Y](yᵉˣᵖ: A2 => Y, coeff: B2) extends TriInterface[Nothing, Nothing, A2, B2, Nothing, Nothing, Y]
+      case class Term3[A3, B3, Y](yᵉˣᵖ: A3 => Y, coeff: B3) extends TriInterface[Nothing, Nothing, Nothing, Nothing, A3, B3, Y]
+    sealed trait TriStore[+S1, +S2, +S3, Y] extends Trinomial[S1, S1, S2, S2, S3, S3, Y]
+    object TriStore:
+      case class Term1[S1, Y](yᵉˣᵖ: S1 => Y, coeff: S1) extends TriStore[S1, Nothing, Nothing, Y]
+      case class Term2[S2, Y](yᵉˣᵖ: S2 => Y, coeff: S2) extends TriStore[Nothing, S2, Nothing, Y]
+      case class Term3[S3, Y](yᵉˣᵖ: S3 => Y, coeff: S3) extends TriStore[Nothing, Nothing, S3, Y]

--- a/modules/poly/shared/src/main/scala/polynomial/product/Composition.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/product/Composition.scala
@@ -1,6 +1,6 @@
 package polynomial.product
 
-import polynomial.`object`.Mono
+import polynomial.`object`.Monomial.{Interface, Store}
 
 type ◁[P[_], Q[_]] = Composition[P, Q, _]
 
@@ -8,9 +8,9 @@ abstract class Composition[P[_], Q[_], Y]
 object Composition:
 
   type Decompose[P[_], Q[_], Y] = (P[Y], Q[Y]) match
-    case (Mono.Interface[a1, b1, Y], Mono.Interface[a2, b2, Y]) => (b1, b2)
-    case (Mono.Store[s1, Y], Mono.Store[s2, Y])                 => (s1, s2)
+    case (Interface[a1, b1, Y], Interface[a2, b2, Y]) => (b1, b2)
+    case (Store[s1, Y], Store[s2, Y])                 => (s1, s2)
 
   type DecomposeSharp[P[_], Q[_], Y] = (P[Y], Q[Y]) match
-    case (Mono.Interface[a1, b1, Y], Mono.Interface[a2, b2, Y]) => (a1, a2)
-    case (Mono.Store[s1, Y], Mono.Store[s2, Y])                 => (s1, s2)
+    case (Interface[a1, b1, Y], Interface[a2, b2, Y]) => (a1, a2)
+    case (Store[s1, Y], Store[s2, Y])                 => (s1, s2)

--- a/modules/poly/shared/src/main/scala/polynomial/product/Composition.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/product/Composition.scala
@@ -1,6 +1,6 @@
 package polynomial.product
 
-import polynomial.`object`.Monomial
+import polynomial.`object`.Mono
 
 type ◁[P[_], Q[_]] = Composition[P, Q, _]
 
@@ -8,9 +8,9 @@ abstract class Composition[P[_], Q[_], Y]
 object Composition:
 
   type Decompose[P[_], Q[_], Y] = (P[Y], Q[Y]) match
-    case (Monomial.Interface[a1, b1, Y], Monomial.Interface[a2, b2, Y]) => (b1, b2)
-    case (Monomial.Store[s1, Y], Monomial.Store[s2, Y])                 => (s1, s2)
+    case (Mono.Interface[a1, b1, Y], Mono.Interface[a2, b2, Y]) => (b1, b2)
+    case (Mono.Store[s1, Y], Mono.Store[s2, Y])                 => (s1, s2)
 
   type DecomposeSharp[P[_], Q[_], Y] = (P[Y], Q[Y]) match
-    case (Monomial.Interface[a1, b1, Y], Monomial.Interface[a2, b2, Y]) => (a1, a2)
-    case (Monomial.Store[s1, Y], Monomial.Store[s2, Y])                 => (s1, s2)
+    case (Mono.Interface[a1, b1, Y], Mono.Interface[a2, b2, Y]) => (a1, a2)
+    case (Mono.Store[s1, Y], Mono.Store[s2, Y])                 => (s1, s2)

--- a/modules/poly/shared/src/main/scala/polynomial/product/Tensor.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/product/Tensor.scala
@@ -1,7 +1,7 @@
 package polynomial.product
 
 import polynomial.morphism.PolyMap
-import polynomial.`object`.{Binomial, Monomial}
+import polynomial.`object`.{Bi, Mono}
 
 type ⊗[P[_], Q[_]] = Tensor[P, Q, _]
 
@@ -9,11 +9,11 @@ abstract class Tensor[P[_], Q[_], Y]
 object Tensor:
   
   type DayConvolution[P[_], Q[_], Y] = (P[Y], Q[Y]) match
-    case (Binomial.Interface[a1, b1, a2, b2, Y], Binomial.Interface[a3, b3, a4, b4, Y]) => Binomial.Interface[(a1, a3), (b1, b3), (a2, a4), (b2, b4), Y]
-    case (Monomial.Interface[a1, b1, Y], Binomial.Interface[a2, b2, a3, b3, Y])         => Binomial.Interface[(a1, a2), (b1, b2), (a1, a3), (b1, b3), Y]
-    case (Monomial.Interface[a1, b1, Y], Monomial.Interface[a2, b2, Y])                 => Monomial.Interface[(a1, a2), (b1, b2), Y]
-    case (Monomial.Store[s1, Y], Monomial.Store[s2, Y])                                 => Monomial.Store[(s1, s2), Y]
+    case (Bi.Interface[a1, b1, a2, b2, Y], Bi.Interface[a3, b3, a4, b4, Y]) => Bi.Interface[(a1, a3), (b1, b3), (a2, a4), (b2, b4), Y]
+    case (Mono.Interface[a1, b1, Y], Bi.Interface[a2, b2, a3, b3, Y])         => Bi.Interface[(a1, a2), (b1, b2), (a1, a3), (b1, b3), Y]
+    case (Mono.Interface[a1, b1, Y], Mono.Interface[a2, b2, Y])                 => Mono.Interface[(a1, a2), (b1, b2), Y]
+    case (Mono.Store[s1, Y], Mono.Store[s2, Y])                                 => Mono.Store[(s1, s2), Y]
     case (PolyMap[o, p, Y], PolyMap[q, r, Y])                                           => PolyMap[DayConvolution[o, q, _], DayConvolution[p, r, _], Y]
-    case (Tensor[o, p, Y], Binomial.Interface[a1, b1, a2, b2, Y])                       => DayConvolution[DayConvolution[o, p, _], Binomial.Interface[a1, b1, a2, b2, _], Y]
-    case (Tensor[o, p, Y], Monomial.Interface[a1, b1, Y])                               => DayConvolution[DayConvolution[o, p, _], Monomial.Interface[a1, b1, _], Y]
-    case (Tensor[o, p, Y], Monomial.Store[s1, Y])                                       => DayConvolution[DayConvolution[o, p, _], Monomial.Store[s1, _], Y]
+    case (Tensor[o, p, Y], Bi.Interface[a1, b1, a2, b2, Y])                       => DayConvolution[DayConvolution[o, p, _], Bi.Interface[a1, b1, a2, b2, _], Y]
+    case (Tensor[o, p, Y], Mono.Interface[a1, b1, Y])                               => DayConvolution[DayConvolution[o, p, _], Mono.Interface[a1, b1, _], Y]
+    case (Tensor[o, p, Y], Mono.Store[s1, Y])                                       => DayConvolution[DayConvolution[o, p, _], Mono.Store[s1, _], Y]

--- a/modules/poly/shared/src/main/scala/polynomial/product/Tensor.scala
+++ b/modules/poly/shared/src/main/scala/polynomial/product/Tensor.scala
@@ -1,7 +1,8 @@
 package polynomial.product
 
 import polynomial.morphism.PolyMap
-import polynomial.`object`.{Bi, Mono}
+import polynomial.`object`.Binomial.BiInterface
+import polynomial.`object`.Monomial.{Interface, Store}
 
 type ⊗[P[_], Q[_]] = Tensor[P, Q, _]
 
@@ -9,11 +10,11 @@ abstract class Tensor[P[_], Q[_], Y]
 object Tensor:
   
   type DayConvolution[P[_], Q[_], Y] = (P[Y], Q[Y]) match
-    case (Bi.Interface[a1, b1, a2, b2, Y], Bi.Interface[a3, b3, a4, b4, Y]) => Bi.Interface[(a1, a3), (b1, b3), (a2, a4), (b2, b4), Y]
-    case (Mono.Interface[a1, b1, Y], Bi.Interface[a2, b2, a3, b3, Y])         => Bi.Interface[(a1, a2), (b1, b2), (a1, a3), (b1, b3), Y]
-    case (Mono.Interface[a1, b1, Y], Mono.Interface[a2, b2, Y])                 => Mono.Interface[(a1, a2), (b1, b2), Y]
-    case (Mono.Store[s1, Y], Mono.Store[s2, Y])                                 => Mono.Store[(s1, s2), Y]
-    case (PolyMap[o, p, Y], PolyMap[q, r, Y])                                           => PolyMap[DayConvolution[o, q, _], DayConvolution[p, r, _], Y]
-    case (Tensor[o, p, Y], Bi.Interface[a1, b1, a2, b2, Y])                       => DayConvolution[DayConvolution[o, p, _], Bi.Interface[a1, b1, a2, b2, _], Y]
-    case (Tensor[o, p, Y], Mono.Interface[a1, b1, Y])                               => DayConvolution[DayConvolution[o, p, _], Mono.Interface[a1, b1, _], Y]
-    case (Tensor[o, p, Y], Mono.Store[s1, Y])                                       => DayConvolution[DayConvolution[o, p, _], Mono.Store[s1, _], Y]
+    case (BiInterface[a1, b1, a2, b2, Y], BiInterface[a3, b3, a4, b4, Y]) => BiInterface[(a1, a3), (b1, b3), (a2, a4), (b2, b4), Y]
+    case (Interface[a1, b1, Y], BiInterface[a2, b2, a3, b3, Y])           => BiInterface[(a1, a2), (b1, b2), (a1, a3), (b1, b3), Y]
+    case (Interface[a1, b1, Y], Interface[a2, b2, Y])                     => Interface[(a1, a2), (b1, b2), Y]
+    case (Store[s1, Y], Store[s2, Y])                                     => Store[(s1, s2), Y]
+    case (PolyMap[o, p, Y], PolyMap[q, r, Y])                             => PolyMap[DayConvolution[o, q, _], DayConvolution[p, r, _], Y]
+    case (Tensor[o, p, Y], BiInterface[a1, b1, a2, b2, Y])                => DayConvolution[DayConvolution[o, p, _], BiInterface[a1, b1, a2, b2, _], Y]
+    case (Tensor[o, p, Y], Interface[a1, b1, Y])                          => DayConvolution[DayConvolution[o, p, _], Interface[a1, b1, _], Y]
+    case (Tensor[o, p, Y], Store[s1, Y])                                  => DayConvolution[DayConvolution[o, p, _], Store[s1, _], Y]

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,12 @@
 // cross
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.14.0")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.16")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.15.0")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.17")
 
 // docs
 addSbtPlugin("org.scalameta"      % "sbt-mdoc"                      % "2.5.2")
 
 // publish
 addSbtPlugin("com.github.sbt"     % "sbt-ci-release"                % "1.5.12")
-addSbtPlugin("org.typelevel"      % "sbt-typelevel-no-publish"      % "0.6.2")
+addSbtPlugin("org.typelevel"      % "sbt-typelevel-no-publish"      % "0.6.6")


### PR DESCRIPTION
 - renaming of types, in order to reduce code footprint
 - add prism composition
 - better parameterization of types, e.g., by `I` and `O`
 - update Scala version to 3.4.0, in order to get access to improved application overloads and improved match types
 - update deps